### PR TITLE
Simplification of OMOP Phenotype with Annotation for Debugging

### DIFF
--- a/ExtractScripts/N3C_extract_pcornet_oracle.sql
+++ b/ExtractScripts/N3C_extract_pcornet_oracle.sql
@@ -1,5 +1,5 @@
 --PCORNet 5.1 extraction code for N3C
---Written by Emily Pfaff, UNC Chapel Hill; Harold Lehmann, JHU
+--Written by Emily Pfaff, UNC Chapel Hill, Harold Lehmann, JHU
 --Code written for MS SQL Server
 --This extract purposefully excludes the following PCORnet tables: ENROLLMENT, HARVEST, HASH_TOKEN, PCORNET_TRIAL
 --Assumptions:

--- a/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
@@ -14,7 +14,7 @@ V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes a
 Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
 HOW TO RUN:
-You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
+You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
 USER NOTES: 
 In OHDSI conventions, we do not usually write tables to the main database schema. 
@@ -135,7 +135,7 @@ union distinct select distinct person_id
 from @cdmDatabaseSchema.condition_occurrence
 where condition_concept_id in (
 		select concept_id
-		from @vocabulary_database_schema.concept
+		from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
 		where concept_id in (
@@ -159,7 +159,7 @@ union distinct select distinct person_id
 from @cdmDatabaseSchema.condition_occurrence
 where condition_concept_id in (
 		select concept_id
-		from @vocabulary_database_schema.concept
+		from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
 		where concept_id in (
@@ -175,8 +175,8 @@ where condition_concept_id in (
 				)
 		
 		union distinct select c.concept_id
-		from @vocabulary_database_schema.concept c
-		join @vocabulary_database_schema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+		from @cdmDatabaseSchema.concept c
+		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
 		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			and ca.ancestor_concept_id in (
 				756044,
@@ -205,7 +205,7 @@ from (
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
-			from @vocabulary_database_schema.concept
+			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -295,7 +295,7 @@ from (
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
-			from @vocabulary_database_schema.concept
+			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -384,7 +384,7 @@ from (
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
-			from @vocabulary_database_schema.concept
+			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -474,7 +474,7 @@ from (
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
-			from @vocabulary_database_schema.concept
+			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those term

--- a/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
@@ -11,6 +11,7 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
+incremental change on 10-29: simplified script
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
 
@@ -25,6 +26,7 @@ Begin building cohort following OHDSI standard cohort definition process
 **/
 
 /** Creating the N3C Cohort table **/
+
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -44,838 +46,495 @@ create table @resultsDatabaseSchema.phenotype_execution (
 );
 
 
--- OHDSI ATLAS generated cohort logic
-/** This block of code generates concept sets to be used in this phenotype**/
-create table @tempDatabaseSchema.u6v5jn5hcodesets (
-  codeset_id INT64 not null,
-  concept_id INT64 not null
-)
-;
-
-/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
-In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-select 0 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
-union distinct select c.concept_id
-  from @cdmDatabaseSchema.concept c
-  join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756055)
-  and c.invalid_reason is null
-
-) i
-) c;
-/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-select 2 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
-
-) i
-) c;
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-select 3 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-union distinct select c.concept_id
-  from @cdmDatabaseSchema.concept c
-  join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-  and c.invalid_reason is null
-
-) i
-) c;
-/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-/
-select 4 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-union distinct select c.concept_id
-  from @cdmDatabaseSchema.concept c
-  join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-  and c.invalid_reason is null
-
-) i
-) c;
-/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-select 5 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
-
-) i
-) c;
-/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
-The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
-You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
-insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
-select 6 as codeset_id, c.concept_id from (select distinct i.concept_id from
-( 
-  select concept_id from @cdmDatabaseSchema.concept where concept_id in (45595484)
-
-) i
-) c;
-
-/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
-It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
-In the case of N3C, we don't impart any rules here.**/
-CREATE TABLE @tempDatabaseSchema.u6v5jn5hqualified_events
- AS WITH primary_events   as (select p.ordinal  as event_id,p.person_id as person_id,p.start_date as start_date,p.end_date as end_date,op_start_date as op_start_date,op_end_date as op_end_date,cast(p.visit_occurrence_id  as int64)  as visit_occurrence_id from (
-  select e.person_id, e.start_date, e.end_date,
-         row_number() over (partition by e.person_id order by e.sort_date asc) ordinal,
-         op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date, cast(e.visit_occurrence_id  as int64) as visit_occurrence_id
-  from 
-  (
-/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
-The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
-  -- Begin Measurement Criteria
-select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
-       c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.measurement_date as sort_date
-from 
-(
-  select m.* 
-  from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) c
-
-where c.measurement_date >= DATE(2020, 01, 01)
-/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
- AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
- OR
- C.value_source_value in ('Positive', 'Present', 'Detected')
- ) **/
- -- End Measurement Criteria
-
-union all
-/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
-
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/**The next code is saying to look for a strong positive before 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) c
-
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-union all
-
-/**The next code is saying to look for a strong positive on or after 04-01-2020**/
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) c
-
-where c.condition_start_date >= DATE(2020, 04, 01)
--- End Condition Occurrence Criteria
-
-union all
-/**The next code is saying to look for a Weak Positive before 04-01-2020**/
-select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) c
-
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-) pe
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
-It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
-AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
-It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
-join (
--- Begin Criteria Group
-select 0 as index_id, person_id, event_id
-from
-/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
-(
-    select e.person_id, e.event_id 
-    from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) c
-/* This code tells it what dates: before 04-01-2020**/
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) e
-  inner join
-  (
-    -- Begin Correlated Criteria
-  select 0 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) c
-/** This code tells it what dates: before 04-01-2020**/
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner join
-(
-  -- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) c
-
-
--- End Condition Occurrence Criteria
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= DATE_ADD(cast(p.start_date as date), interval 0 DAY) and a.start_date <= DATE_ADD(cast(p.start_date as date), interval 0 DAY)
-  group by  p.person_id, p.event_id
- having count(distinct a.target_concept_id) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-   ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
-    group by  e.person_id, e.event_id
-   having count(index_id) = 1
- ) g
--- End Criteria Group
-) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
-
-union all
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
-select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) c
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
--- End Condition Occurrence Criteria
-
-) pe
-join (
--- Begin Criteria Group
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**OCCURRENCE 1**/
-select 0 as index_id, person_id, event_id
+insert into @resultsDatabaseSchema.n3c_cohort
+select distinct person_id
 from
 (
-    select e.person_id, e.event_id 
-    from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) c
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) e
-  inner join
-  (
-    -- Begin Correlated Criteria
-  select 0 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) c
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner join
-/**OCCURRENCE 2**/
-(
-  -- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) c
+
+/**
+
+INCLUSION:
+
+1) Postive COVID Measurement
+2) Strong positive dx
+3) 2x Weak Dx
+4) COVID Measurement & No occurrences of Z11.59 
 
 
--- End Condition Occurrence Criteria
-/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= DATE_ADD(cast(p.start_date as date), interval 0 DAY) and a.start_date <= DATE_ADD(cast(p.start_date as date), interval 0 DAY)
-  group by  p.person_id, p.event_id
- having count(distinct a.target_concept_id) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-   ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
-    group by  e.person_id, e.event_id
-   having count(index_id) = 1
- ) g
--- End Criteria Group
-) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
+**/
 
-union all
-/**We have to now apply logic to look for Asymptomatic patients.
-This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
-Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
-It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
-So we start by building a piece of logic to look at the OBSERVATION domain.**/
-select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
--- Begin Observation Criteria
-select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
-       c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.observation_date as sort_date
-from 
-/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
-(
-  select o.* 
-  from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) c
-/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
-where c.observation_date >= DATE(2020, 04, 01)
--- End Observation Criteria
-
-) pe
-join (
--- Begin Criteria Group
-/**Here's where things get interesting... we want to restrict Z11.59 to be with:
-At least 1 Strong Positive On or After 04-01-2020
- --> but not people who have a lab-confirmed negative
-OR
-At least 1 Strong Positive Before 04-01-2020
- --> but not people who have a lab-confirmed negative
- OR
-At least 1 Lab-confirmed Positive **/
-
-/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
-select 0 as index_id, person_id, event_id
-from
-(
-    select e.person_id, e.event_id 
-    from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Observation Criteria
-select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
-       c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.observation_date as sort_date
-from 
-(
-  select o.* 
-  from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) c
-
-where c.observation_date >= DATE(2020, 04, 01)
--- End Observation Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) e
-  inner join
-  (
-    -- Begin Correlated Criteria
-  select 0 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Observation Criteria
-select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
-       c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.observation_date as sort_date
-from 
-(
-  select o.* 
-  from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) c
-
-where c.observation_date >= DATE(2020, 04, 01)
--- End Observation Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner join
-/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-(
-  select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) c
-/**This is where we impart the date rule: on or after 04-01-2020**/
-where c.condition_start_date >= DATE(2020, 04, 01)
--- End Condition Occurrence Criteria
-
-) pe
-join (
--- Begin Criteria Group
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-select 0 as index_id, person_id, event_id
-from
-(
-    select e.person_id, e.event_id 
-    from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) c
-/**We add the date criteria: on or after 04-01-2020**/
-where c.condition_start_date >= DATE(2020, 04, 01)
--- End Condition Occurrence Criteria
-) q
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) e
-  left join
-  (
-    -- Begin Correlated Criteria
-  select 0 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) c
-
-where c.condition_start_date >= DATE(2020, 04, 01)
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
-inner join
-(
-  -- Begin Measurement Criteria
-select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
-       c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.measurement_date as sort_date
-from 
-/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
-(
-  select m.* 
-  from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) c
-/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
-In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
-where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
-  group by  p.person_id, p.event_id
- having count(a.target_concept_id) >= 1
--- End Correlated Criteria
-
-   ) 
-  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
-  cq on e.person_id = cq.person_id and e.event_id = cq.event_id
-    group by  e.person_id, e.event_id
-   having count(index_id) <= 0
- ) g
--- End Criteria Group
-) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
-  group by  p.person_id, p.event_id
- having count(a.target_concept_id) >= 1
--- End Correlated Criteria
-
-union all
--- Begin Correlated Criteria
-
-/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
-/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
-  select 1 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Observation Criteria
-select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
-       c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.observation_date as sort_date
-from 
-(
-  select o.* 
-  from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) c
-
-where c.observation_date >= DATE(2020, 04, 01)
--- End Observation Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner 
-/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-(
-  select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
--- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-/** This pulling the concept set for Strong Positive Before 04-01-2020**/
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) c
-/**Restricting to after 01-01-2020 and before 04-01-2020**/
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-) pe
-join (
--- Begin Criteria Group
-/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-select 0 as index_id, person_id, event_id
-from
-(
-    select e.person_id, e.event_id 
-    from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) c
-
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) e
-  left join
-  (
-    -- Begin Correlated Criteria
-  select 0 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Condition Occurrence Criteria
-select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
-       c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.condition_start_date as sort_date
-from 
-(
-  select co.* 
-  from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) c
-
-where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
--- End Condition Occurrence Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner join
-/*Now we specifiy the logic to look for a lab-confirmed negative.*/
-(
-  -- Begin Measurement Criteria
-select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
-       c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.measurement_date as sort_date
-from 
-/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
-(
-  select m.* 
-  from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) c
-/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
-where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
-  group by  p.person_id, p.event_id
- having count(a.target_concept_id) >= 1
--- End Correlated Criteria
-/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
-   ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
-    group by  e.person_id, e.event_id
-   having count(index_id) <= 0
- ) g
--- End Criteria Group
-) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
-  group by  p.person_id, p.event_id
- having count(a.target_concept_id) >= 1
--- End Correlated Criteria
-
-union all
-/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
-/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
--- Begin Correlated Criteria
-  select 2 as index_id, p.person_id, p.event_id
-  from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
-from (-- Begin Observation Criteria
-select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
-       c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.observation_date as sort_date
-from 
-(
-  select o.* 
-  from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) c
-/**Restricting to after 04-01-2020**/
-where c.observation_date >= DATE(2020, 04, 01)
--- End Observation Criteria
-) q
-join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
-  and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
-) p
-inner join
-/**Looking in the Measurement table for lab-confirmed positive**/
-(
-  -- Begin Measurement Criteria
-select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
-       c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
-       c.measurement_date as sort_date
-from 
-/**Looking for the LOINC/HCPCS that are COVID**/
-(
-  select m.* 
-  from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) c
-/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
-This is where the logic from MS SQL Line 159-163 should have gone.**/
-where and ( c.value_as_concept_id in (4126681,45877985,45884084,9191)
-or
-c.value_source_value in ('Positive', 'Present', 'Detected')
-	)
-
-
--- End Measurement Criteria
-/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
-) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
-  group by  p.person_id, p.event_id
- having count(a.target_concept_id) >= 1
--- End Correlated Criteria
-
-     ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
-    group by  e.person_id, e.event_id
-   having count(index_id) >= 1
- ) g
--- End Criteria Group
-) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-
-  ) e
-	join @cdmDatabaseSchema.observation_period op on e.person_id = op.person_id and e.start_date >=  op.observation_period_start_date and e.start_date <= op.observation_period_end_date
-  where DATE_ADD(cast(op.observation_period_start_date as date), interval 0 DAY) <= e.start_date and DATE_ADD(cast(e.start_date as date), interval 0 DAY) <= op.observation_period_end_date
-) p
-where p.ordinal = 1
--- End Primary Events
-
-) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
- SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
- FROM (
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date asc) as ordinal, cast(pe.visit_occurrence_id  as int64) as visit_occurrence_id
-  from primary_events pe
-  
-) qe
-
-;
-
-/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
-
---- Inclusion Rule Inserts
-
-create table @tempDatabaseSchema.u6v5jn5hinclusion_events (inclusion_rule_id INT64,
-	person_id INT64,
-	event_id INT64
-);
-
-CREATE TABLE @tempDatabaseSchema.u6v5jn5hincluded_events
- AS WITH cteincludedevents  as (select event_id as event_id,person_id as person_id,start_date as start_date,end_date as end_date,op_start_date as op_start_date,op_end_date as op_end_date,row_number() over (partition by person_id order by start_date asc)  as ordinal from (
-     select q.event_id, q.person_id, q.start_date, q.end_date, q.op_start_date, q.op_end_date, sum(coalesce(cast(power(cast(2  as int64), i.inclusion_rule_id) as int64), 0)) as inclusion_rule_mask
-     from @tempDatabaseSchema.u6v5jn5hqualified_events q
-    left join @tempDatabaseSchema.u6v5jn5hinclusion_events i on i.person_id = q.person_id and i.event_id = q.event_id
-     group by  q.event_id, q.person_id, q.start_date, q.end_date, q.op_start_date, q.op_end_date
-   ) mg -- matching groups
-
-)
- SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date
- FROM cteincludedevents results
-where results.ordinal = 1
-;
-
-
-/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
--- generate cohort periods into #final_cohort
-CREATE TABLE @tempDatabaseSchema.u6v5jn5hcohort_rows
- AS WITH cohort_ends   as (select event_id as event_id,person_id as person_id,op_end_date  as end_date from @tempDatabaseSchema.u6v5jn5hincluded_events
-), first_ends   as (select f.person_id as person_id,f.start_date as start_date,f.end_date
-	 as end_date from (
-	  select i.event_id, i.person_id, i.start_date, e.end_date, row_number() over (partition by i.person_id, i.event_id order by e.end_date) as ordinal 
-	  from @tempDatabaseSchema.u6v5jn5hincluded_events i
-	  join cohort_ends e on i.event_id = e.event_id and i.person_id = e.person_id and e.end_date >= i.start_date
-	) f
-	where f.ordinal = 1
-)
- SELECT person_id, start_date, end_date
- FROM first_ends;
-
-/**More Atlas generated code that largely goes unused.**/
-INSERT INTO @resultsDatabaseSchema.n3c_cohort
- WITH cteenddates   as (select person_id
-		 as person_id,DATE_ADD(cast(event_date as date), interval -1 * 0 DAY)   as end_date from (
-		select
-			person_id
-			, event_date
-			, event_type
-			, max(start_ordinal) over (partition by person_id order by event_date, event_type rows unbounded preceding) as start_ordinal 
-			, row_number() over (partition by person_id order by event_date, event_type) as overall_ord
-		from
-		(
-			select
-				person_id
-				, start_date as event_date
-				, -1 as event_type
-				, row_number() over (partition by person_id order by start_date) as start_ordinal
-			from @tempDatabaseSchema.u6v5jn5hcohort_rows
+-- 1) Positive COVID Measurement
+select distinct person_id
+from @cdmDatabaseSchema.measurement
+where measurement_concept_id in (
+		select concept_id
+		from @cdmDatabaseSchema.concept
+		where concept_id in (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
 		
-			union all
+		union distinct select c.concept_id
+		from @cdmDatabaseSchema.concept c
+		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+			and ca.ancestor_concept_id in (756055)
+			and c.invalid_reason is null
+		)
+	and measurement_date >= DATE(2020, 01, 01)
+	and (
+		value_as_concept_id in (
+			4126681,
+			45877985,
+			45884084,
+			9191
+			)
+		or value_source_value in (
+			'Positive'
+			,'Present'
+			,'Detected'
+			)
+		)
+
+union distinct select distinct person_id
+from @cdmDatabaseSchema.condition_occurrence
+where condition_concept_id in (
+		select concept_id
+		from @vocabulary_database_schema.concept
+		where concept_id in (
+				260125
+				,260139
+				,46271075
+				,4307774
+				,4195694
+				,257011
+				,442555
+				,4059022
+				,4059021
+				,256451
+				,4059003
+				,4168213
+				,434490
+				,439676
+				,254761
+				,4048098
+				,37311061
+				,4100065
+				,320136
+				,4038519
+				,312437
+				,4060052
+				,4263848
+				,37311059
+				,37016200
+				,4011766
+				,437663
+				,4141062
+				,4164645
+				,4047610
+				,4260205
+				,4185711
+				,4289517
+				,4140453
+				,4090569
+				,4109381
+				,4330445
+				,255848
+				,4102774
+				,436235
+				,261326
+				,320651
+				)
+		)
+	and condition_start_date between DATE(2020, 01, 01)
+		and DATE(2020, 03, 31)
+
+union distinct select distinct person_id
+from @cdmDatabaseSchema.condition_occurrence
+where condition_concept_id in (
+		select concept_id
+		from @vocabulary_database_schema.concept
+		where concept_id in (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
 		
+		union distinct select c.concept_id
+		from @vocabulary_database_schema.concept c
+		join @vocabulary_database_schema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+			and ca.ancestor_concept_id in (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+			and c.invalid_reason is null
+		)
+	and condition_start_date >= DATE(2020, 04, 01)
 
-			select
-				person_id
-				, DATE_ADD(cast(end_date as date), interval 0 DAY) as end_date
-				, 1 as event_type
-				, null
-			from @tempDatabaseSchema.u6v5jn5hcohort_rows
-		) rawdata
-	) e
-	where (2 * e.start_ordinal) - e.overall_ord = 0
-), cteends   as ( select c.person_id
-		 as person_id,c.start_date
-		 as start_date,min(e.end_date)  as end_date  from @tempDatabaseSchema.u6v5jn5hcohort_rows c
-	join cteenddates e on c.person_id = e.person_id and e.end_date >= c.start_date
-	 group by  c.person_id, c.start_date
- ), final_cohort   as ( select person_id as person_id,min(start_date)  as start_date,end_date
- as end_date  from cteends
- group by  1, 3 )
+union distinct select distinct person_id
+from (
+	  select person_id
+		,visit_occurrence_id
+		,count(*)
+	  from @cdmDatabaseSchema.condition_occurrence
+	where condition_concept_id in (
+			select concept_id
+			from @vocabulary_database_schema.concept
+			where concept_id in (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		and condition_start_date between DATE(2020, 01, 01)
+			and DATE(2020, 03, 31)
+	  group by  1, 2 having count(*) >= 2
+	 ) dx_same_encounter
 
-/**The final collapsing of ALL the logic into the cohort table.**/
---# BEGIN N3C_COHORT table to be retained
+union distinct select distinct person_id
+from (
+	  select person_id
+		,condition_start_date
+		,count(*)
+	  from @cdmDatabaseSchema.condition_occurrence
+	where condition_concept_id in (
+			select concept_id
+			from @vocabulary_database_schema.concept
+			where concept_id in (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		and condition_start_date between DATE(2020, 01, 01)
+			and DATE(2020, 03, 31)
+	  group by  1, 2 having count(*) >= 2
+	 ) dx_same_date
 
---SELECT person_id
- SELECT distinct
-    person_id
-from final_cohort;
+union distinct select distinct person_id
+from (
+	  select person_id
+		,visit_occurrence_id
+		,count(*)
+	  from @cdmDatabaseSchema.condition_occurrence
+	where condition_concept_id in (
+			select concept_id
+			from @vocabulary_database_schema.concept
+			where concept_id in (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		and condition_start_date >= DATE(2020, 04, 01)
+	  group by  1, 2 having count(*) >= 2
+	 ) dx_same_encounter
+
+union distinct select distinct person_id
+from (
+	  select person_id
+		,condition_start_date
+		,count(*)
+	  from @cdmDatabaseSchema.condition_occurrence
+	where condition_concept_id in (
+			select concept_id
+			from @vocabulary_database_schema.concept
+			where concept_id in (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		and condition_start_date >= DATE(2020, 04, 01)
+	  group by  1, 2 having count(*) >= 2
+	 ) dx_same_date
+
+union distinct select distinct person_id
+from @cdmDatabaseSchema.measurement
+where measurement_concept_id in (
+		select concept_id
+		from @cdmDatabaseSchema.concept
+		where concept_id in (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		union distinct select c.concept_id
+		from @cdmDatabaseSchema.concept c
+		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+			and ca.ancestor_concept_id in (756055)
+			and c.invalid_reason is null
+		)
+	and measurement_date >= DATE(2020, 01, 01)
+	-- existence of Z11.59
+	and person_id not in (
+		select person_id
+		from @cdmDatabaseSchema.observation
+		where observation_source_concept_id = 45595484
+			and observation_date >= DATE(2020, 04, 01)
+		)
+		
+		
+) 
+;
+
+
 
 insert into @resultsDatabaseSchema.phenotype_execution
 select
@@ -883,19 +542,3 @@ select
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version from @cdmDatabaseSchema.vocabulary where vocabulary_id='None' LIMIT 1) as vocabulary_version;
 
-/**Dropping out all the temp tables.**/
-
-DELETE FROM @tempDatabaseSchema.u6v5jn5hcohort_rows WHERE True;
-drop table @tempDatabaseSchema.u6v5jn5hcohort_rows;
-
-DELETE FROM @tempDatabaseSchema.u6v5jn5hinclusion_events WHERE True;
-drop table @tempDatabaseSchema.u6v5jn5hinclusion_events;
-
-DELETE FROM @tempDatabaseSchema.u6v5jn5hqualified_events WHERE True;
-drop table @tempDatabaseSchema.u6v5jn5hqualified_events;
-
-DELETE FROM @tempDatabaseSchema.u6v5jn5hincluded_events WHERE True;
-drop table @tempDatabaseSchema.u6v5jn5hincluded_events;
-
-DELETE FROM @tempDatabaseSchema.u6v5jn5hcodesets WHERE True;
-drop table @tempDatabaseSchema.u6v5jn5hcodesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
@@ -16,9 +16,9 @@ Script changes between 10-29 & 11-05: simplified script to human-written SQL (ve
 HOW TO RUN:
 You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-USER NOTES: 
-In OHDSI conventions, we do not usually write tables to the main database schema. 
-OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+USER NOTES:
+In OHDSI conventions, we do not usually write tables to the main database schema.
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis.
 We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
 To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
@@ -49,10 +49,6 @@ create table @resultsDatabaseSchema.phenotype_execution (
 
 
 insert into @resultsDatabaseSchema.n3c_cohort
-select distinct person_id
-from
-(
-
 -- Phenotype Entry Criteria: A lab confirmed positive test
 select distinct person_id
 from @cdmDatabaseSchema.measurement
@@ -100,7 +96,7 @@ where measurement_concept_id in (
 				,757686
 				,756055
 				)
-		
+
 		union distinct select c.concept_id
 		from @cdmDatabaseSchema.concept c
 		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
@@ -173,7 +169,7 @@ where condition_concept_id in (
 				756081,
 				37310285
 				)
-		
+
 		union distinct select c.concept_id
 		from @cdmDatabaseSchema.concept c
 		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
@@ -196,7 +192,7 @@ where condition_concept_id in (
 				)
 			and c.invalid_reason is null
 		)
-	
+
 	and condition_start_date >= DATE(2020, 04, 01)
 
 union distinct select distinct person_id
@@ -298,7 +294,7 @@ from (
 			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			where concept_id in (
 					260125,
 					260139,
@@ -387,7 +383,7 @@ from (
 			from @cdmDatabaseSchema.concept
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			where concept_id in (
 					260125,
 					260139,
@@ -576,7 +572,7 @@ where measurement_concept_id in (
 				,757686
 				,756055
 				)
-		
+
 		union distinct select c.concept_id
 		from @cdmDatabaseSchema.concept c
 		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
@@ -595,10 +591,7 @@ where measurement_concept_id in (
 		where observation_source_concept_id = 45595484
 			and observation_date >= DATE(2020, 04, 01)
 		)
-		
-		
-) 
-;
+		;
 
 
 

--- a/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
@@ -10,17 +10,10 @@ V2.0 - dropping weak diagnosis after May 1, adding asymptomatic test code (Z11.5
 changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
-
-Instructions:
-Cohorts were assembled using OHDSI Atlas (atlas-covid19.ohdsi.org)
-This MS SQL script is the artifact of this ATLAS cohort definition: http://atlas-covid19.ohdsi.org/#/cohortdefinition/1119
-If desired to evaluate feasibility of each cohort, individual cohorts are available:
-1- Lab-confirmed positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/655)
-2- Lab-confirmed negative cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/656)
-3- Suspected positive cases	(http://atlas-covid19.ohdsi.org/#/cohortdefinition/657)
-4- Possible positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/658)
+V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+
 Harmonization note:
 In OHDSI conventions, we do not usually write tables to the main database schema.
 NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
@@ -31,6 +24,7 @@ Begin building cohort following OHDSI standard cohort definition process
 
 **/
 
+/** Creating the N3C Cohort table **/
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -49,14 +43,18 @@ create table @resultsDatabaseSchema.phenotype_execution (
 	vocabulary_version STRING
 );
 
+
 -- OHDSI ATLAS generated cohort logic
-create table @tempDatabaseSchema.nrbjfyyocodesets (
+/** This block of code generates concept sets to be used in this phenotype**/
+create table @tempDatabaseSchema.u6v5jn5hcodesets (
   codeset_id INT64 not null,
   concept_id INT64 not null
 )
 ;
 
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
+In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
 select 0 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
@@ -68,14 +66,20 @@ union distinct select c.concept_id
 
 ) i
 ) c;
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
 select 2 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
 
 ) i
 ) c;
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 select 3 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
@@ -87,7 +91,11 @@ union distinct select c.concept_id
 
 ) i
 ) c;
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
+/
 select 4 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
@@ -99,14 +107,20 @@ union distinct select c.concept_id
 
 ) i
 ) c;
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
 select 5 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
 
 ) i
 ) c;
-insert into @tempDatabaseSchema.nrbjfyyocodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
+The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
+You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
+insert into @tempDatabaseSchema.u6v5jn5hcodesets (codeset_id, concept_id)
 select 6 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ( 
   select concept_id from @cdmDatabaseSchema.concept where concept_id in (45595484)
@@ -114,14 +128,18 @@ select 6 as codeset_id, c.concept_id from (select distinct i.concept_id from
 ) i
 ) c;
 
-
-CREATE TABLE @tempDatabaseSchema.nrbjfyyoqualified_events
+/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
+It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
+In the case of N3C, we don't impart any rules here.**/
+CREATE TABLE @tempDatabaseSchema.u6v5jn5hqualified_events
  AS WITH primary_events   as (select p.ordinal  as event_id,p.person_id as person_id,p.start_date as start_date,p.end_date as end_date,op_start_date as op_start_date,op_end_date as op_end_date,cast(p.visit_occurrence_id  as int64)  as visit_occurrence_id from (
   select e.person_id, e.start_date, e.end_date,
          row_number() over (partition by e.person_id order by e.sort_date asc) ordinal,
          op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date, cast(e.visit_occurrence_id  as int64) as visit_occurrence_id
   from 
   (
+/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
+The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
   -- Begin Measurement Criteria
 select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
        c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
@@ -130,32 +148,38 @@ from
 (
   select m.* 
   from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) c
 
 where c.measurement_date >= DATE(2020, 01, 01)
-and ( c.value_as_concept_id in (4126681,45877985,45884084,9191)
-	or
-	c.value_source_value in ('Positive', 'Present', 'Detected')
-	)
--- End Measurement Criteria
+/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
+ AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+ OR
+ C.value_source_value in ('Positive', 'Present', 'Detected')
+ ) **/
+ -- End Measurement Criteria
 
 union all
+/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
+
 -- Begin Condition Occurrence Criteria
 select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/**The next code is saying to look for a strong positive before 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) c
 
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
 -- End Condition Occurrence Criteria
 
 union all
+
+/**The next code is saying to look for a strong positive on or after 04-01-2020**/
 -- Begin Condition Occurrence Criteria
 select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
@@ -164,13 +188,14 @@ from
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) c
 
 where c.condition_start_date >= DATE(2020, 04, 01)
 -- End Condition Occurrence Criteria
 
 union all
+/**The next code is saying to look for a Weak Positive before 04-01-2020**/
 select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
 -- Begin Condition Occurrence Criteria
 select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
@@ -180,17 +205,22 @@ from
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) c
 
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
 -- End Condition Occurrence Criteria
 
 ) pe
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
+It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
+AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
+It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
 join (
 -- Begin Criteria Group
 select 0 as index_id, person_id, event_id
 from
+/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
 (
     select e.person_id, e.event_id 
     from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
@@ -199,12 +229,13 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) c
-
+/* This code tells it what dates: before 04-01-2020**/
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
 -- End Condition Occurrence Criteria
 ) q
@@ -221,12 +252,13 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) c
-
+/** This code tells it what dates: before 04-01-2020**/
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
 -- End Condition Occurrence Criteria
 ) q
@@ -240,46 +272,53 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) c
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
 ) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= DATE_ADD(cast(p.start_date as date), interval 0 DAY) and a.start_date <= DATE_ADD(cast(p.start_date as date), interval 0 DAY)
   group by  p.person_id, p.event_id
  having count(distinct a.target_concept_id) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
    ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
     group by  e.person_id, e.event_id
    having count(index_id) = 1
  ) g
 -- End Criteria Group
 ) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
+/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
 
 union all
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
 select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
 -- Begin Condition Occurrence Criteria
 select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) c
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
 -- End Condition Occurrence Criteria
 
 ) pe
 join (
 -- Begin Criteria Group
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**OCCURRENCE 1**/
 select 0 as index_id, person_id, event_id
 from
 (
@@ -290,12 +329,13 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) c
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
 -- End Condition Occurrence Criteria
 ) q
@@ -312,12 +352,13 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) c
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 where (c.condition_start_date >= DATE(2020, 04, 01) and c.condition_start_date <= DATE(2020, 05, 01))
 -- End Condition Occurrence Criteria
 ) q
@@ -325,52 +366,71 @@ join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
 inner join
+/**OCCURRENCE 2**/
 (
   -- Begin Condition Occurrence Criteria
 select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_date as start_date, coalesce(c.condition_end_date, DATE_ADD(cast(c.condition_start_date as date), interval 1 DAY)) as end_date,
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) c
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
 ) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= DATE_ADD(cast(p.start_date as date), interval 0 DAY) and a.start_date <= DATE_ADD(cast(p.start_date as date), interval 0 DAY)
   group by  p.person_id, p.event_id
  having count(distinct a.target_concept_id) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
    ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
     group by  e.person_id, e.event_id
    having count(index_id) = 1
  ) g
 -- End Criteria Group
 ) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
+/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
 
 union all
+/**We have to now apply logic to look for Asymptomatic patients.
+This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
+Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
+It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
+So we start by building a piece of logic to look at the OBSERVATION domain.**/
 select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
 -- Begin Observation Criteria
 select c.person_id, c.observation_id as event_id, c.observation_date as start_date, DATE_ADD(cast(c.observation_date as date), interval 1 DAY) as end_date,
        c.observation_concept_id as target_concept_id, c.visit_occurrence_id,
        c.observation_date as sort_date
 from 
+/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
 (
   select o.* 
   from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) c
-
+/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
 where c.observation_date >= DATE(2020, 04, 01)
 -- End Observation Criteria
 
 ) pe
 join (
 -- Begin Criteria Group
+/**Here's where things get interesting... we want to restrict Z11.59 to be with:
+At least 1 Strong Positive On or After 04-01-2020
+ --> but not people who have a lab-confirmed negative
+OR
+At least 1 Strong Positive Before 04-01-2020
+ --> but not people who have a lab-confirmed negative
+ OR
+At least 1 Lab-confirmed Positive **/
+
+/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
 select 0 as index_id, person_id, event_id
 from
 (
@@ -384,7 +444,7 @@ from
 (
   select o.* 
   from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) c
 
 where c.observation_date >= DATE(2020, 04, 01)
@@ -406,7 +466,7 @@ from
 (
   select o.* 
   from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) c
 
 where c.observation_date >= DATE(2020, 04, 01)
@@ -416,6 +476,7 @@ join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
 inner join
+/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 (
   select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
 -- Begin Condition Occurrence Criteria
@@ -423,18 +484,22 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) c
-
+/**This is where we impart the date rule: on or after 04-01-2020**/
 where c.condition_start_date >= DATE(2020, 04, 01)
 -- End Condition Occurrence Criteria
 
 ) pe
 join (
 -- Begin Criteria Group
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 select 0 as index_id, person_id, event_id
 from
 (
@@ -445,15 +510,19 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) c
-
+/**We add the date criteria: on or after 04-01-2020**/
 where c.condition_start_date >= DATE(2020, 04, 01)
 -- End Condition Occurrence Criteria
 ) q
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) e
@@ -470,7 +539,7 @@ from
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) c
 
 where c.condition_start_date >= DATE(2020, 04, 01)
@@ -479,6 +548,7 @@ where c.condition_start_date >= DATE(2020, 04, 01)
 join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
+/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
 inner join
 (
   -- Begin Measurement Criteria
@@ -486,27 +556,31 @@ select c.person_id, c.measurement_id as event_id, c.measurement_date as start_da
        c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
        c.measurement_date as sort_date
 from 
+/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
 (
   select m.* 
   from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) c
-
+/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
+In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
 where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
-
+/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
 ) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
   group by  p.person_id, p.event_id
  having count(a.target_concept_id) >= 1
 -- End Correlated Criteria
 
-   ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
+   ) 
+  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
+  cq on e.person_id = cq.person_id and e.event_id = cq.event_id
     group by  e.person_id, e.event_id
    having count(index_id) <= 0
  ) g
 -- End Criteria Group
 ) ac on ac.person_id = pe.person_id and ac.event_id = pe.event_id
-
+/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
 ) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
   group by  p.person_id, p.event_id
  having count(a.target_concept_id) >= 1
@@ -514,6 +588,9 @@ where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
 
 union all
 -- Begin Correlated Criteria
+
+/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
+/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
   select 1 as index_id, p.person_id, p.event_id
   from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
 from (-- Begin Observation Criteria
@@ -524,7 +601,7 @@ from
 (
   select o.* 
   from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) c
 
 where c.observation_date >= DATE(2020, 04, 01)
@@ -533,7 +610,10 @@ where c.observation_date >= DATE(2020, 04, 01)
 join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id 
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
-inner join
+inner 
+/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 (
   select pe.person_id, pe.event_id, pe.start_date, pe.end_date, pe.target_concept_id, pe.visit_occurrence_id, pe.sort_date from (
 -- Begin Condition Occurrence Criteria
@@ -541,18 +621,20 @@ select c.person_id, c.condition_occurrence_id as event_id, c.condition_start_dat
        c.condition_concept_id as target_concept_id, c.visit_occurrence_id,
        c.condition_start_date as sort_date
 from 
+/** This pulling the concept set for Strong Positive Before 04-01-2020**/
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) c
-
+/**Restricting to after 01-01-2020 and before 04-01-2020**/
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
 -- End Condition Occurrence Criteria
 
 ) pe
 join (
 -- Begin Criteria Group
+/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 select 0 as index_id, person_id, event_id
 from
 (
@@ -566,7 +648,7 @@ from
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) c
 
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
@@ -588,7 +670,7 @@ from
 (
   select co.* 
   from @cdmDatabaseSchema.condition_occurrence co
-  join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) c
 
 where (c.condition_start_date >= DATE(2020, 01, 01) and c.condition_start_date <= DATE(2020, 03, 31))
@@ -598,18 +680,20 @@ join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
 inner join
+/*Now we specifiy the logic to look for a lab-confirmed negative.*/
 (
   -- Begin Measurement Criteria
 select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
        c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
        c.measurement_date as sort_date
 from 
+/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
 (
   select m.* 
   from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) c
-
+/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
 where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
 
@@ -617,7 +701,7 @@ where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
   group by  p.person_id, p.event_id
  having count(a.target_concept_id) >= 1
 -- End Correlated Criteria
-
+/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
    ) cq on e.person_id = cq.person_id and e.event_id = cq.event_id
     group by  e.person_id, e.event_id
    having count(index_id) <= 0
@@ -631,6 +715,8 @@ where c.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
 -- End Correlated Criteria
 
 union all
+/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
+/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
 -- Begin Correlated Criteria
   select 2 as index_id, p.person_id, p.event_id
   from (select q.person_id, q.event_id, q.start_date, q.end_date, q.visit_occurrence_id, op.observation_period_start_date as op_start_date, op.observation_period_end_date as op_end_date
@@ -642,9 +728,9 @@ from
 (
   select o.* 
   from @cdmDatabaseSchema.observation o
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) c
-
+/**Restricting to after 04-01-2020**/
 where c.observation_date >= DATE(2020, 04, 01)
 -- End Observation Criteria
 ) q
@@ -652,21 +738,29 @@ join @cdmDatabaseSchema.observation_period op on q.person_id = op.person_id
   and op.observation_period_start_date <= q.start_date and op.observation_period_end_date >= q.start_date
 ) p
 inner join
+/**Looking in the Measurement table for lab-confirmed positive**/
 (
   -- Begin Measurement Criteria
 select c.person_id, c.measurement_id as event_id, c.measurement_date as start_date, DATE_ADD(cast(c.measurement_date as date), interval 1 DAY) as end_date,
        c.measurement_concept_id as target_concept_id, c.visit_occurrence_id,
        c.measurement_date as sort_date
 from 
+/**Looking for the LOINC/HCPCS that are COVID**/
 (
   select m.* 
   from @cdmDatabaseSchema.measurement m
-join @tempDatabaseSchema.nrbjfyyocodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+join @tempDatabaseSchema.u6v5jn5hcodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) c
+/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
+This is where the logic from MS SQL Line 159-163 should have gone.**/
+where and ( c.value_as_concept_id in (4126681,45877985,45884084,9191)
+or
+c.value_source_value in ('Positive', 'Present', 'Detected')
+	)
 
-where c.value_as_concept_id in (4126681,45877985,45884084,9191)
+
 -- End Measurement Criteria
-
+/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
 ) a on a.person_id = p.person_id  and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date and a.start_date >= p.op_start_date and a.start_date <= p.op_end_date
   group by  p.person_id, p.event_id
  having count(a.target_concept_id) >= 1
@@ -686,7 +780,7 @@ where c.value_as_concept_id in (4126681,45877985,45884084,9191)
 where p.ordinal = 1
 -- End Primary Events
 
-)
+) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
  FROM (
   select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date asc) as ordinal, cast(pe.visit_occurrence_id  as int64) as visit_occurrence_id
@@ -696,18 +790,20 @@ where p.ordinal = 1
 
 ;
 
+/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
+
 --- Inclusion Rule Inserts
 
-create table @tempDatabaseSchema.nrbjfyyoinclusion_events (inclusion_rule_id INT64,
+create table @tempDatabaseSchema.u6v5jn5hinclusion_events (inclusion_rule_id INT64,
 	person_id INT64,
 	event_id INT64
 );
 
-CREATE TABLE @tempDatabaseSchema.nrbjfyyoincluded_events
+CREATE TABLE @tempDatabaseSchema.u6v5jn5hincluded_events
  AS WITH cteincludedevents  as (select event_id as event_id,person_id as person_id,start_date as start_date,end_date as end_date,op_start_date as op_start_date,op_end_date as op_end_date,row_number() over (partition by person_id order by start_date asc)  as ordinal from (
      select q.event_id, q.person_id, q.start_date, q.end_date, q.op_start_date, q.op_end_date, sum(coalesce(cast(power(cast(2  as int64), i.inclusion_rule_id) as int64), 0)) as inclusion_rule_mask
-     from @tempDatabaseSchema.nrbjfyyoqualified_events q
-    left join @tempDatabaseSchema.nrbjfyyoinclusion_events i on i.person_id = q.person_id and i.event_id = q.event_id
+     from @tempDatabaseSchema.u6v5jn5hqualified_events q
+    left join @tempDatabaseSchema.u6v5jn5hinclusion_events i on i.person_id = q.person_id and i.event_id = q.event_id
      group by  q.event_id, q.person_id, q.start_date, q.end_date, q.op_start_date, q.op_end_date
    ) mg -- matching groups
 
@@ -718,14 +814,14 @@ where results.ordinal = 1
 ;
 
 
-
+/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
 -- generate cohort periods into #final_cohort
-CREATE TABLE @tempDatabaseSchema.nrbjfyyocohort_rows
- AS WITH cohort_ends   as (select event_id as event_id,person_id as person_id,op_end_date  as end_date from @tempDatabaseSchema.nrbjfyyoincluded_events
+CREATE TABLE @tempDatabaseSchema.u6v5jn5hcohort_rows
+ AS WITH cohort_ends   as (select event_id as event_id,person_id as person_id,op_end_date  as end_date from @tempDatabaseSchema.u6v5jn5hincluded_events
 ), first_ends   as (select f.person_id as person_id,f.start_date as start_date,f.end_date
 	 as end_date from (
 	  select i.event_id, i.person_id, i.start_date, e.end_date, row_number() over (partition by i.person_id, i.event_id order by e.end_date) as ordinal 
-	  from @tempDatabaseSchema.nrbjfyyoincluded_events i
+	  from @tempDatabaseSchema.u6v5jn5hincluded_events i
 	  join cohort_ends e on i.event_id = e.event_id and i.person_id = e.person_id and e.end_date >= i.start_date
 	) f
 	where f.ordinal = 1
@@ -733,6 +829,7 @@ CREATE TABLE @tempDatabaseSchema.nrbjfyyocohort_rows
  SELECT person_id, start_date, end_date
  FROM first_ends;
 
+/**More Atlas generated code that largely goes unused.**/
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
  WITH cteenddates   as (select person_id
 		 as person_id,DATE_ADD(cast(event_date as date), interval -1 * 0 DAY)   as end_date from (
@@ -749,7 +846,7 @@ INSERT INTO @resultsDatabaseSchema.n3c_cohort
 				, start_date as event_date
 				, -1 as event_type
 				, row_number() over (partition by person_id order by start_date) as start_ordinal
-			from @tempDatabaseSchema.nrbjfyyocohort_rows
+			from @tempDatabaseSchema.u6v5jn5hcohort_rows
 		
 			union all
 		
@@ -759,19 +856,20 @@ INSERT INTO @resultsDatabaseSchema.n3c_cohort
 				, DATE_ADD(cast(end_date as date), interval 0 DAY) as end_date
 				, 1 as event_type
 				, null
-			from @tempDatabaseSchema.nrbjfyyocohort_rows
+			from @tempDatabaseSchema.u6v5jn5hcohort_rows
 		) rawdata
 	) e
 	where (2 * e.start_ordinal) - e.overall_ord = 0
 ), cteends   as ( select c.person_id
 		 as person_id,c.start_date
-		 as start_date,min(e.end_date)  as end_date  from @tempDatabaseSchema.nrbjfyyocohort_rows c
+		 as start_date,min(e.end_date)  as end_date  from @tempDatabaseSchema.u6v5jn5hcohort_rows c
 	join cteenddates e on c.person_id = e.person_id and e.end_date >= c.start_date
 	 group by  c.person_id, c.start_date
  ), final_cohort   as ( select person_id as person_id,min(start_date)  as start_date,end_date
  as end_date  from cteends
  group by  1, 3 )
 
+/**The final collapsing of ALL the logic into the cohort table.**/
 --# BEGIN N3C_COHORT table to be retained
 
 --SELECT person_id
@@ -785,18 +883,19 @@ select
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version from @cdmDatabaseSchema.vocabulary where vocabulary_id='None' LIMIT 1) as vocabulary_version;
 
+/**Dropping out all the temp tables.**/
 
-DELETE FROM @tempDatabaseSchema.nrbjfyyocohort_rows WHERE True;
-drop table @tempDatabaseSchema.nrbjfyyocohort_rows;
+DELETE FROM @tempDatabaseSchema.u6v5jn5hcohort_rows WHERE True;
+drop table @tempDatabaseSchema.u6v5jn5hcohort_rows;
 
-DELETE FROM @tempDatabaseSchema.nrbjfyyoinclusion_events WHERE True;
-drop table @tempDatabaseSchema.nrbjfyyoinclusion_events;
+DELETE FROM @tempDatabaseSchema.u6v5jn5hinclusion_events WHERE True;
+drop table @tempDatabaseSchema.u6v5jn5hinclusion_events;
 
-DELETE FROM @tempDatabaseSchema.nrbjfyyoqualified_events WHERE True;
-drop table @tempDatabaseSchema.nrbjfyyoqualified_events;
+DELETE FROM @tempDatabaseSchema.u6v5jn5hqualified_events WHERE True;
+drop table @tempDatabaseSchema.u6v5jn5hqualified_events;
 
-DELETE FROM @tempDatabaseSchema.nrbjfyyoincluded_events WHERE True;
-drop table @tempDatabaseSchema.nrbjfyyoincluded_events;
+DELETE FROM @tempDatabaseSchema.u6v5jn5hincluded_events WHERE True;
+drop table @tempDatabaseSchema.u6v5jn5hincluded_events;
 
-DELETE FROM @tempDatabaseSchema.nrbjfyyocodesets WHERE True;
-drop table @tempDatabaseSchema.nrbjfyyocodesets;
+DELETE FROM @tempDatabaseSchema.u6v5jn5hcodesets WHERE True;
+drop table @tempDatabaseSchema.u6v5jn5hcodesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_bigquery.sql
@@ -1,5 +1,5 @@
 /**
-Change log:
+CHANGE LOG:
 V1.1 - initial commit
 V1.2 - updated possible positive cases (typo in name of concept set name) and added additional NIH VSAC codeset_id
 V1.3 - consolidated to single cohort definition and added N3C COHORT table + labeling statements
@@ -11,17 +11,18 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
-incremental change on 10-29: simplified script
+Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
-To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+HOW TO RUN:
+You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-Harmonization note:
-In OHDSI conventions, we do not usually write tables to the main database schema.
-NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+USER NOTES: 
+In OHDSI conventions, we do not usually write tables to the main database schema. 
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
-
-Begin building cohort following OHDSI standard cohort definition process
-
+SCRIPT RELEASE DATE: 11-05-2020
 
 **/
 
@@ -39,6 +40,7 @@ create table @resultsDatabaseSchema.n3c_cohort (
 DROP TABLE IF EXISTS @resultsDatabaseSchema.phenotype_execution;
 
 -- Create dest table
+-- Here we need to know when you ran the phenotype, what version you're using and what vocabulary version you've built your OMOP concepts on
 create table @resultsDatabaseSchema.phenotype_execution (
 	run_datetime datetime not null,
 	phenotype_version STRING not null,
@@ -51,24 +53,13 @@ select distinct person_id
 from
 (
 
-/**
-
-INCLUSION:
-
-1) Postive COVID Measurement
-2) Strong positive dx
-3) 2x Weak Dx
-4) COVID Measurement & No occurrences of Z11.59 
-
-
-**/
-
--- 1) Positive COVID Measurement
+-- Phenotype Entry Criteria: A lab confirmed positive test
 select distinct person_id
 from @cdmDatabaseSchema.measurement
 where measurement_concept_id in (
 		select concept_id
 		from @cdmDatabaseSchema.concept
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		where concept_id in (
 				586515
 				,586522
@@ -113,17 +104,26 @@ where measurement_concept_id in (
 		union distinct select c.concept_id
 		from @cdmDatabaseSchema.concept c
 		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			and ca.ancestor_concept_id in (756055)
 			and c.invalid_reason is null
 		)
+	-- Here we add a date restriction: after January 1, 2020
 	and measurement_date >= DATE(2020, 01, 01)
 	and (
+	-- The value_as_concept field is where we store standardized qualitative results
+	-- The concept ids here represent LOINC or SNOMED codes for standard ways to code a lab that is positive
 		value_as_concept_id in (
-			4126681,
-			45877985,
-			45884084,
-			9191
+			45878583
+			,37079494
+			,1177295
+			,36307756
+			,36309158
+			,36308436
+			,9189
 			)
+	-- To be exhaustive, we also look for Positive strings in the value_source_value field
 		or value_source_value in (
 			'Positive'
 			,'Present'
@@ -136,51 +136,22 @@ from @cdmDatabaseSchema.condition_occurrence
 where condition_concept_id in (
 		select concept_id
 		from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 		where concept_id in (
-				260125
-				,260139
-				,46271075
-				,4307774
-				,4195694
-				,257011
-				,442555
-				,4059022
-				,4059021
-				,256451
-				,4059003
-				,4168213
-				,434490
-				,439676
-				,254761
-				,4048098
-				,37311061
-				,4100065
-				,320136
-				,4038519
-				,312437
-				,4060052
-				,4263848
-				,37311059
-				,37016200
-				,4011766
-				,437663
-				,4141062
-				,4164645
-				,4047610
-				,4260205
-				,4185711
-				,4289517
-				,4140453
-				,4090569
-				,4109381
-				,4330445
-				,255848
-				,4102774
-				,436235
-				,261326
-				,320651
-				)
+			756023,
+			756044,
+			756061,
+			756031,
+			37311061,
+			756081,
+			37310285,
+			756039,
+			320651,
+			37311060
+			)
 		)
+	-- This logic imposes the restriction: these codes were only valid as Strong Positive codes between January 1, 2020 and March 31, 2020
 	and condition_start_date between DATE(2020, 01, 01)
 		and DATE(2020, 03, 31)
 
@@ -189,237 +160,324 @@ from @cdmDatabaseSchema.condition_occurrence
 where condition_concept_id in (
 		select concept_id
 		from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- This is the list of standard concepts that represent those terms
 		where concept_id in (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				37311061,
+				37311060,
+				756023,
+				756031,
+				756039,
+				756044,
+				756061,
+				756081,
+				37310285
 				)
 		
 		union distinct select c.concept_id
 		from @vocabulary_database_schema.concept c
 		join @vocabulary_database_schema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			and ca.ancestor_concept_id in (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				756044,
+				37310285,
+				37310283,
+				756061,
+				756081,
+				37310287,
+				756023,
+				756031,
+				37310286,
+				37311061,
+				37310284,
+				756039,
+				37311060,
+				37310254
 				)
 			and c.invalid_reason is null
 		)
+	
 	and condition_start_date >= DATE(2020, 04, 01)
 
 union distinct select distinct person_id
 from (
 	  select person_id
-		,visit_occurrence_id
-		,count(*)
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
 			from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 			where concept_id in (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		and condition_start_date between DATE(2020, 01, 01)
 			and DATE(2020, 03, 31)
-	  group by  1, 2 having count(*) >= 2
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+	  group by  1, visit_occurrence_id
+	 having count(*) >= 2
 	 ) dx_same_encounter
 
 union distinct select distinct person_id
 from (
 	  select person_id
-		,condition_start_date
-		,count(*)
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
 			from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			where concept_id in (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		and condition_start_date between DATE(2020, 01, 01)
 			and DATE(2020, 03, 31)
-	  group by  1, 2 having count(*) >= 2
+	  group by  1, condition_start_date
+	 having count(*) >= 2
 	 ) dx_same_date
 
 union distinct select distinct person_id
 from (
 	  select person_id
-		,visit_occurrence_id
-		,count(*)
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
 			from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			where concept_id in (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
-					,320651
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971,
+					320651
 					)
 			)
+	-- This code list is only valid for CDC guidance before 04-01-2020
 		and condition_start_date >= DATE(2020, 04, 01)
-	  group by  1, 2 having count(*) >= 2
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		  group by  1, visit_occurrence_id
+	 having count(*) >= 2
 	 ) dx_same_encounter
 
 union distinct select distinct person_id
 from (
 	  select person_id
-		,condition_start_date
-		,count(*)
 	  from @cdmDatabaseSchema.condition_occurrence
 	where condition_concept_id in (
 			select concept_id
 			from @vocabulary_database_schema.concept
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those term
 			where concept_id in (
 					260125
 					,260139
@@ -465,8 +523,11 @@ from (
 					,320651
 					)
 			)
+		-- This code list is based on CDC Guidance for code use AFTER 04-01-2020
 		and condition_start_date >= DATE(2020, 04, 01)
-	  group by  1, 2 having count(*) >= 2
+-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		  group by  1, condition_start_date
+	 having count(*) >= 2
 	 ) dx_same_date
 
 union distinct select distinct person_id
@@ -474,6 +535,7 @@ from @cdmDatabaseSchema.measurement
 where measurement_concept_id in (
 		select concept_id
 		from @cdmDatabaseSchema.concept
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		where concept_id in (
 				586515
 				,586522
@@ -518,11 +580,15 @@ where measurement_concept_id in (
 		union distinct select c.concept_id
 		from @cdmDatabaseSchema.concept c
 		join @cdmDatabaseSchema.concept_ancestor ca on c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			and ca.ancestor_concept_id in (756055)
 			and c.invalid_reason is null
 		)
 	and measurement_date >= DATE(2020, 01, 01)
 	-- existence of Z11.59
+	-- Z11.59 here is being pulled from the source_concept_id
+	-- we want to make extra sure that we're ONLY looking at Z11.59 not the more general SNOMED code that would be in the standard concept id column for this
 	and person_id not in (
 		select person_id
 		from @cdmDatabaseSchema.observation
@@ -541,4 +607,3 @@ select
     CURRENT_DATE() as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version from @cdmDatabaseSchema.vocabulary where vocabulary_id='None' LIMIT 1) as vocabulary_version;
-

--- a/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
@@ -16,9 +16,9 @@ Script changes between 10-29 & 11-05: simplified script to human-written SQL (ve
 HOW TO RUN:
 You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-USER NOTES: 
-In OHDSI conventions, we do not usually write tables to the main database schema. 
-OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+USER NOTES:
+In OHDSI conventions, we do not usually write tables to the main database schema.
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis.
 We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
 To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
@@ -51,10 +51,6 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 
 
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
-SELECT DISTINCT person_id
-FROM
-(
-
 -- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
@@ -102,9 +98,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -184,9 +180,9 @@ WHERE condition_concept_id IN (
 				756081,
 				37310285
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -209,7 +205,7 @@ WHERE condition_concept_id IN (
 				)
 			AND c.invalid_reason IS NULL
 		)
-	
+
 	AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 
 UNION
@@ -320,7 +316,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -415,7 +411,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -566,7 +562,7 @@ FROM (
 UNION
 
 -- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
--- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020,
 -- and does NOT also have a record of a positive covid test or a “strong positive” diagnosis code.
 
 -- We begin by looking for ANY COVID measurement
@@ -616,9 +612,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -637,10 +633,7 @@ WHERE measurement_concept_id IN (
 		WHERE observation_source_concept_id = 45595484
 			AND observation_date >= DATEFROMPARTS(2020, 04, 01)
 		)
-		
-		
-) 
-;
+		;
 
 
 

--- a/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
@@ -14,7 +14,7 @@ V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes a
 Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
 HOW TO RUN:
-You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
+You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
 USER NOTES: 
 In OHDSI conventions, we do not usually write tables to the main database schema. 
@@ -143,7 +143,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -170,7 +170,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -188,8 +188,8 @@ WHERE condition_concept_id IN (
 		UNION
 		
 		SELECT c.concept_id
-		FROM @vocabulary_database_schema.CONCEPT c
-		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
 		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
 				756044,
@@ -223,7 +223,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -317,7 +317,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -412,7 +412,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -506,7 +506,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those term

--- a/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
@@ -10,17 +10,10 @@ V2.0 - dropping weak diagnosis after May 1, adding asymptomatic test code (Z11.5
 changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
-
-Instructions:
-Cohorts were assembled using OHDSI Atlas (atlas-covid19.ohdsi.org)
-This MS SQL script is the artifact of this ATLAS cohort definition: http://atlas-covid19.ohdsi.org/#/cohortdefinition/1119
-If desired to evaluate feasibility of each cohort, individual cohorts are available:
-1- Lab-confirmed positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/655)
-2- Lab-confirmed negative cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/656)
-3- Suspected positive cases	(http://atlas-covid19.ohdsi.org/#/cohortdefinition/657)
-4- Possible positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/658)
+V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+
 Harmonization note:
 In OHDSI conventions, we do not usually write tables to the main database schema.
 NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
@@ -31,6 +24,7 @@ Begin building cohort following OHDSI standard cohort definition process
 
 **/
 
+/** Creating the N3C Cohort table **/
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 IF OBJECT_ID('@resultsDatabaseSchema.n3c_cohort', 'U') IS NOT NULL           -- Drop temp table if it exists
   DROP TABLE @resultsDatabaseSchema.n3c_cohort;
@@ -51,13 +45,17 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	vocabulary_version varchar(50) NULL
 );
 
+
 -- OHDSI ATLAS generated cohort logic
+/** This block of code generates concept sets to be used in this phenotype**/
 CREATE TABLE #Codesets (
   codeset_id int NOT NULL,
   concept_id bigint NOT NULL
 )
 ;
 
+/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
+In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -70,6 +68,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -78,6 +79,9 @@ SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 INSERT INTO #Codesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
@@ -89,7 +93,11 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
+/
 SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
@@ -101,6 +109,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -108,6 +119,9 @@ SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 
 ) I
 ) C;
+/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
+The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
+You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -116,7 +130,9 @@ SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 
-
+/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
+It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
+In the case of N3C, we don't impart any rules here.**/
 with primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id) as
 (
 -- Begin Primary Events
@@ -128,6 +144,8 @@ FROM
          OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
   FROM 
   (
+/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
+The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -140,18 +158,22 @@ JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and 
 ) C
 
 WHERE C.measurement_date >= DATEFROMPARTS(2020, 01, 01)
-AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-	OR
-	C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
--- End Measurement Criteria
+/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
+ AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+ OR
+ C.value_source_value in ('Positive', 'Present', 'Detected')
+ ) **/
+ -- End Measurement Criteria
 
 UNION ALL
+/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
+
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**The next code is saying to look for a strong positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -162,6 +184,8 @@ WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_sta
 -- End Condition Occurrence Criteria
 
 UNION ALL
+
+/**The next code is saying to look for a strong positive on or after 04-01-2020**/
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -177,6 +201,7 @@ WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 -- End Condition Occurrence Criteria
 
 UNION ALL
+/**The next code is saying to look for a Weak Positive before 04-01-2020**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
@@ -193,10 +218,15 @@ WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_sta
 -- End Condition Occurrence Criteria
 
 ) PE
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
+It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
+AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
+It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
 JOIN (
 -- Begin Criteria Group
 select 0 as index_id, person_id, event_id
 FROM
+/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
 (
   select E.person_id, E.event_id 
   FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -205,12 +235,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/* This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
 -- End Condition Occurrence Criteria
 ) Q
@@ -227,12 +258,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/** This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
 -- End Condition Occurrence Criteria
 ) Q
@@ -246,6 +278,7 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -254,38 +287,44 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,0,P.START_DATE) AND A.START_DATE <= DATEADD(day,0,P.START_DATE)
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
 
 UNION ALL
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**OCCURRENCE 1**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -296,12 +335,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
 -- End Condition Occurrence Criteria
 ) Q
@@ -318,12 +358,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
 -- End Condition Occurrence Criteria
 ) Q
@@ -331,12 +372,14 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**OCCURRENCE 2**/
 (
   -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -345,38 +388,55 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,0,P.START_DATE) AND A.START_DATE <= DATEADD(day,0,P.START_DATE)
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
 
 UNION ALL
+/**We have to now apply logic to look for Asymptomatic patients.
+This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
+Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
+It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
+So we start by building a piece of logic to look at the OBSERVATION domain.**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Observation Criteria
 select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
        C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.observation_date as sort_date
 from 
+/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
 (
   select o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
 WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
 -- End Observation Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**Here's where things get interesting... we want to restrict Z11.59 to be with:
+At least 1 Strong Positive On or After 04-01-2020
+ --> but not people who have a lab-confirmed negative
+OR
+At least 1 Strong Positive Before 04-01-2020
+ --> but not people who have a lab-confirmed negative
+ OR
+At least 1 Lab-confirmed Positive **/
+
+/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -422,6 +482,7 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -429,18 +490,22 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**This is where we impart the date rule: on or after 04-01-2020**/
 WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -451,15 +516,19 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**We add the date criteria: on or after 04-01-2020**/
 WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 -- End Condition Occurrence Criteria
 ) Q
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) E
@@ -485,6 +554,7 @@ WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
+/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
 INNER JOIN
 (
   -- Begin Measurement Criteria
@@ -492,27 +562,31 @@ select C.person_id, C.measurement_id as event_id, C.measurement_date as start_da
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
+In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
-
+/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
+  ) 
+  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
+  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
+/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -520,6 +594,9 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 
 UNION ALL
 -- Begin Correlated Criteria
+
+/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
+/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
 SELECT 1 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
 FROM (-- Begin Observation Criteria
@@ -539,7 +616,10 @@ WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
-INNER JOIN
+INNER 
+/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -547,18 +627,20 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This pulling the concept set for Strong Positive Before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) C
-
+/**Restricting to after 01-01-2020 and before 04-01-2020**/
 WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -604,18 +686,20 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we specifiy the logic to look for a lab-confirmed negative.*/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
 
@@ -623,7 +707,7 @@ WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
-
+/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
@@ -637,6 +721,8 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
 UNION ALL
+/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
+/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
 -- Begin Correlated Criteria
 SELECT 2 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -650,7 +736,7 @@ from
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**Restricting to after 04-01-2020**/
 WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
 -- End Observation Criteria
 ) Q
@@ -658,21 +744,29 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**Looking in the Measurement table for lab-confirmed positive**/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**Looking for the LOINC/HCPCS that are COVID**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
+/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
+This is where the logic from MS SQL Line 159-163 should have gone.**/
+WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+OR
+C.value_source_value in ('Positive', 'Present', 'Detected')
+	)
 
-WHERE C.value_as_concept_id in (4126681,45877985,45884084,9191)
+
 -- End Measurement Criteria
-
+/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -692,7 +786,7 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 WHERE P.ordinal = 1
 -- End Primary Events
 
-)
+) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
 SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
@@ -703,6 +797,8 @@ FROM
 ) QE
 
 ;
+
+/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
 
 --- Inclusion Rule Inserts
 
@@ -730,7 +826,7 @@ WHERE Results.ordinal = 1
 ;
 
 
-
+/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
 -- generate cohort periods into #final_cohort
 with cohort_ends (event_id, person_id, end_date) as
 (
@@ -752,7 +848,8 @@ select person_id, start_date, end_date
 INTO #cohort_rows
 from first_ends;
 
-with cteEndDates (person_id, end_date) AS -- the magic
+/**More Atlas generated code that largely goes unused.**/
+with cteEndDates (person_id, end_date) AS 
 (	
 	SELECT
 		person_id
@@ -804,6 +901,7 @@ from cteEnds
 group by person_id, end_date
 )
 
+/**The final collapsing of ALL the logic into the cohort table.**/
 --# BEGIN N3C_COHORT table to be retained
 
 --SELECT person_id
@@ -818,6 +916,7 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
 
+/**Dropping out all the temp tables.**/
 
 TRUNCATE TABLE #cohort_rows;
 DROP TABLE #cohort_rows;

--- a/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
@@ -1,5 +1,5 @@
 /**
-Change log:
+CHANGE LOG:
 V1.1 - initial commit
 V1.2 - updated possible positive cases (typo in name of concept set name) and added additional NIH VSAC codeset_id
 V1.3 - consolidated to single cohort definition and added N3C COHORT table + labeling statements
@@ -11,17 +11,18 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
-incremental change on 10-29: simplified script
+Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
-To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+HOW TO RUN:
+You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-Harmonization note:
-In OHDSI conventions, we do not usually write tables to the main database schema.
-NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+USER NOTES: 
+In OHDSI conventions, we do not usually write tables to the main database schema. 
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
-
-Begin building cohort following OHDSI standard cohort definition process
-
+SCRIPT RELEASE DATE: 11-05-2020
 
 **/
 
@@ -41,6 +42,7 @@ IF OBJECT_ID('@resultsDatabaseSchema.phenotype_execution', 'U') IS NOT NULL     
   DROP TABLE @resultsDatabaseSchema.phenotype_execution;
 
 -- Create dest table
+-- Here we need to know when you ran the phenotype, what version you're using and what vocabulary version you've built your OMOP concepts on
 CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	run_datetime datetime2 NOT NULL,
 	phenotype_version varchar(50) NOT NULL,
@@ -53,24 +55,13 @@ SELECT DISTINCT person_id
 FROM
 (
 
-/**
-
-INCLUSION:
-
-1) Postive COVID Measurement
-2) Strong positive dx
-3) 2x Weak Dx
-4) COVID Measurement & No occurrences of Z11.59 
-
-
-**/
-
--- 1) Positive COVID Measurement
+-- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -117,17 +108,26 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
+	-- Here we add a date restriction: after January 1, 2020
 	AND measurement_date >= DATEFROMPARTS(2020, 01, 01)
 	AND (
+	-- The value_as_concept field is where we store standardized qualitative results
+	-- The concept ids here represent LOINC or SNOMED codes for standard ways to code a lab that is positive
 		value_as_concept_id IN (
-			4126681,
-			45877985,
-			45884084,
-			9191
+			45878583
+			,37079494
+			,1177295
+			,36307756
+			,36309158
+			,36308436
+			,9189
 			)
+	-- To be exhaustive, we also look for Positive strings in the value_source_value field
 		OR value_source_value IN (
 			'Positive'
 			,'Present'
@@ -137,88 +137,52 @@ WHERE measurement_concept_id IN (
 
 UNION
 
--- 2) Strong positive 
--- prior to 04-01
+-- Phenotype Entry Criteria: ONE or more of the “Strong Positive” diagnosis codes from the ICD-10 or SNOMED tables
+-- This section constructs entry logic prior to the CDC guidance issued on April 1, 2020
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				260125
-				,260139
-				,46271075
-				,4307774
-				,4195694
-				,257011
-				,442555
-				,4059022
-				,4059021
-				,256451
-				,4059003
-				,4168213
-				,434490
-				,439676
-				,254761
-				,4048098
-				,37311061
-				,4100065
-				,320136
-				,4038519
-				,312437
-				,4060052
-				,4263848
-				,37311059
-				,37016200
-				,4011766
-				,437663
-				,4141062
-				,4164645
-				,4047610
-				,4260205
-				,4185711
-				,4289517
-				,4140453
-				,4090569
-				,4109381
-				,4330445
-				,255848
-				,4102774
-				,436235
-				,261326
-				,320651
-				)
+			756023,
+			756044,
+			756061,
+			756031,
+			37311061,
+			756081,
+			37310285,
+			756039,
+			320651,
+			37311060
+			)
 		)
+	-- This logic imposes the restriction: these codes were only valid as Strong Positive codes between January 1, 2020 and March 31, 2020
 	AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
 		AND DATEFROMPARTS(2020, 03, 31)
 
 UNION
 
--- after 04-01
+-- The CDC issued guidance on April 1, 2020 that changed COVID coding conventions
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				37311061,
+				37311060,
+				756023,
+				756031,
+				756039,
+				756044,
+				756061,
+				756081,
+				37310285
 				)
 		
 		UNION
@@ -226,90 +190,119 @@ WHERE condition_concept_id IN (
 		SELECT c.concept_id
 		FROM @vocabulary_database_schema.CONCEPT c
 		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				756044,
+				37310285,
+				37310283,
+				756061,
+				756081,
+				37310287,
+				756023,
+				756031,
+				37310286,
+				37311061,
+				37310284,
+				756039,
+				37311060,
+				37310254
 				)
 			AND c.invalid_reason IS NULL
 		)
+	
 	AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
 
 UNION
 
--- 3) 2x Weak diagnosis 
--- prior to 04-01
--- same visit 
+-- 3) TWO or more of the “Weak Positive” diagnosis codes from the ICD-10 or SNOMED tables (below) during the same encounter or on the same date
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same date
+-- BEFORE 04-01-2020 "WEAK POSITIVE" LOGIC:
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
 			AND DATEFROMPARTS(2020, 03, 31)
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
 	GROUP BY person_id
 		,visit_occurrence_id
 	HAVING count(*) >= 2
@@ -317,60 +310,90 @@ FROM (
 
 UNION
 
--- same date
+-- Now we apply logic to look for same visit AND same date
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,condition_start_date
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
 			AND DATEFROMPARTS(2020, 03, 31)
 	GROUP BY person_id
@@ -380,17 +403,113 @@ FROM (
 
 UNION
 
--- after 04-01
--- same visit 
+-- AFTER 04-01-2020 "WEAK POSITIVE" LOGIC:
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same visit
+
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
+			WHERE concept_id IN (
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971,
+					320651
+					)
+			)
+	-- This code list is only valid for CDC guidance before 04-01-2020
+		AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- Now we apply logic to look for same visit AND same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those term
 			WHERE concept_id IN (
 					260125
 					,260139
@@ -436,84 +555,27 @@ FROM (
 					,320651
 					)
 			)
+		-- This code list is based on CDC Guidance for code use AFTER 04-01-2020
 		AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
-	GROUP BY person_id
-		,visit_occurrence_id
-	HAVING count(*) >= 2
-	) dx_same_encounter
-
-UNION
-
--- same date
-SELECT DISTINCT person_id
-FROM (
-	SELECT person_id
-		,condition_start_date
-		,count(*)
-	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-	WHERE condition_concept_id IN (
-			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
-			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
-					,320651
-					)
-			)
-		AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
-	GROUP BY person_id
+-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
 		,condition_start_date
 	HAVING count(*) >= 2
 	) dx_same_date
 
 UNION
 
--- 4) COVID Measurement & No occurrences of Z11.59 
--- COVID lab test of any result
+-- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- and does NOT also have a record of a positive covid test or a “strong positive” diagnosis code.
+
+-- We begin by looking for ANY COVID measurement
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -560,11 +622,15 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
 	AND measurement_date >= DATEFROMPARTS(2020, 01, 01)
 	-- existence of Z11.59
+	-- Z11.59 here is being pulled from the source_concept_id
+	-- we want to make extra sure that we're ONLY looking at Z11.59 not the more general SNOMED code that would be in the standard concept id column for this
 	AND person_id NOT IN (
 		SELECT person_id
 		FROM @cdmDatabaseSchema.OBSERVATION
@@ -583,4 +649,3 @@ SELECT
     GETDATE() as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
-

--- a/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_mssql.sql
@@ -11,6 +11,7 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
+incremental change on 10-29: simplified script
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
 
@@ -25,6 +26,7 @@ Begin building cohort following OHDSI standard cohort definition process
 **/
 
 /** Creating the N3C Cohort table **/
+
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 IF OBJECT_ID('@resultsDatabaseSchema.n3c_cohort', 'U') IS NOT NULL           -- Drop temp table if it exists
   DROP TABLE @resultsDatabaseSchema.n3c_cohort;
@@ -46,869 +48,535 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 );
 
 
--- OHDSI ATLAS generated cohort logic
-/** This block of code generates concept sets to be used in this phenotype**/
-CREATE TABLE #Codesets (
-  codeset_id int NOT NULL,
-  concept_id bigint NOT NULL
-)
-;
-
-/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
-In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756055)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
-
-) I
-) C;
-INSERT INTO #Codesets (codeset_id, concept_id)
-/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-/
-SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
-
-) I
-) C;
-/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
-The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
-You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (45595484)
-
-) I
-) C;
-
-/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
-It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
-In the case of N3C, we don't impart any rules here.**/
-with primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id) as
-(
--- Begin Primary Events
-select P.ordinal as event_id, P.person_id, P.start_date, P.end_date, op_start_date, op_end_date, cast(P.visit_occurrence_id as bigint) as visit_occurrence_id
-FROM
-(
-  select E.person_id, E.start_date, E.end_date,
-         row_number() OVER (PARTITION BY E.person_id ORDER BY E.sort_date ASC) ordinal,
-         OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM 
-  (
-/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
-The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-
-WHERE C.measurement_date >= DATEFROMPARTS(2020, 01, 01)
-/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
- AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
- OR
- C.value_source_value in ('Positive', 'Present', 'Detected')
- ) **/
- -- End Measurement Criteria
-
-UNION ALL
-/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
-
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**The next code is saying to look for a strong positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-UNION ALL
-
-/**The next code is saying to look for a strong positive on or after 04-01-2020**/
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
--- End Condition Occurrence Criteria
-
-UNION ALL
-/**The next code is saying to look for a Weak Positive before 04-01-2020**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-) PE
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
-It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
-AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
-It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
-JOIN (
--- Begin Criteria Group
-select 0 as index_id, person_id, event_id
-FROM
-/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/* This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/** This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,0,P.START_DATE) AND A.START_DATE <= DATEADD(day,0,P.START_DATE)
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
-
-UNION ALL
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**OCCURRENCE 1**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 04, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 05, 01))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**OCCURRENCE 2**/
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,0,P.START_DATE) AND A.START_DATE <= DATEADD(day,0,P.START_DATE)
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
-
-UNION ALL
-/**We have to now apply logic to look for Asymptomatic patients.
-This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
-Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
-It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
-So we start by building a piece of logic to look at the OBSERVATION domain.**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
-WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
--- End Observation Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**Here's where things get interesting... we want to restrict Z11.59 to be with:
-At least 1 Strong Positive On or After 04-01-2020
- --> but not people who have a lab-confirmed negative
-OR
-At least 1 Strong Positive Before 04-01-2020
- --> but not people who have a lab-confirmed negative
- OR
-At least 1 Lab-confirmed Positive **/
-
-/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**This is where we impart the date rule: on or after 04-01-2020**/
-WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**We add the date criteria: on or after 04-01-2020**/
-WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
--- End Condition Occurrence Criteria
-) Q
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= DATEFROMPARTS(2020, 04, 01)
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
-INNER JOIN
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
-In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) 
-  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
-  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
--- Begin Correlated Criteria
-
-/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
-/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
-SELECT 1 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER 
-/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This pulling the concept set for Strong Positive Before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-/**Restricting to after 01-01-2020 and before 04-01-2020**/
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= DATEFROMPARTS(2020, 01, 01) and C.condition_start_date <= DATEFROMPARTS(2020, 03, 31))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we specifiy the logic to look for a lab-confirmed negative.*/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
-/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
-/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
--- Begin Correlated Criteria
-SELECT 2 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**Restricting to after 04-01-2020**/
-WHERE C.observation_date >= DATEFROMPARTS(2020, 04, 01)
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**Looking in the Measurement table for lab-confirmed positive**/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**Looking for the LOINC/HCPCS that are COVID**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
-This is where the logic from MS SQL Line 159-163 should have gone.**/
-WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-OR
-C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
-
-
--- End Measurement Criteria
-/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) >= 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-  ) E
-	JOIN @cdmDatabaseSchema.observation_period OP on E.person_id = OP.person_id and E.start_date >=  OP.observation_period_start_date and E.start_date <= op.observation_period_end_date
-  WHERE DATEADD(day,0,OP.OBSERVATION_PERIOD_START_DATE) <= E.START_DATE AND DATEADD(day,0,E.START_DATE) <= OP.OBSERVATION_PERIOD_END_DATE
-) P
-WHERE P.ordinal = 1
--- End Primary Events
-
-) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
-INTO #qualified_events
-FROM 
-(
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date ASC) as ordinal, cast(pe.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM primary_events pe
-  
-) QE
-
-;
-
-/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
-
---- Inclusion Rule Inserts
-
-create table #inclusion_events (inclusion_rule_id bigint,
-	person_id bigint,
-	event_id bigint
-);
-
-with cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal) as
-(
-  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, row_number() over (partition by person_id order by start_date ASC) as ordinal
-  from
-  (
-    select Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as bigint), I.inclusion_rule_id), 0)) as inclusion_rule_mask
-    from #qualified_events Q
-    LEFT JOIN #inclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
-    GROUP BY Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date
-  ) MG -- matching groups
-
-)
-select event_id, person_id, start_date, end_date, op_start_date, op_end_date
-into #included_events
-FROM cteIncludedEvents Results
-WHERE Results.ordinal = 1
-;
-
-
-/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
--- generate cohort periods into #final_cohort
-with cohort_ends (event_id, person_id, end_date) as
-(
-	-- cohort exit dates
-  -- By default, cohort exit at the event's op end date
-select event_id, person_id, op_end_date as end_date from #included_events
-),
-first_ends (person_id, start_date, end_date) as
-(
-	select F.person_id, F.start_date, F.end_date
-	FROM (
-	  select I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
-	  from #included_events I
-	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
-	) F
-	WHERE F.ordinal = 1
-)
-select person_id, start_date, end_date
-INTO #cohort_rows
-from first_ends;
-
-/**More Atlas generated code that largely goes unused.**/
-with cteEndDates (person_id, end_date) AS 
-(	
-	SELECT
-		person_id
-		, DATEADD(day,-1 * 0, event_date)  as end_date
-	FROM
-	(
-		SELECT
-			person_id
-			, event_date
-			, event_type
-			, MAX(start_ordinal) OVER (PARTITION BY person_id ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal 
-			, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY event_date, event_type) AS overall_ord
-		FROM
-		(
-			SELECT
-				person_id
-				, start_date AS event_date
-				, -1 AS event_type
-				, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date) AS start_ordinal
-			FROM #cohort_rows
-		
-			UNION ALL
-		
-
-			SELECT
-				person_id
-				, DATEADD(day,0,end_date) as end_date
-				, 1 AS event_type
-				, NULL
-			FROM #cohort_rows
-		) RAWDATA
-	) e
-	WHERE (2 * e.start_ordinal) - e.overall_ord = 0
-),
-cteEnds (person_id, start_date, end_date) AS
-(
-	SELECT
-		 c.person_id
-		, c.start_date
-		, MIN(e.end_date) AS end_date
-	FROM #cohort_rows c
-	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
-	GROUP BY c.person_id, c.start_date
-),
-final_cohort (person_id, start_date, end_date) AS
-(
-select person_id, min(start_date) as start_date, end_date
-from cteEnds
-group by person_id, end_date
-)
-
-/**The final collapsing of ALL the logic into the cohort table.**/
---# BEGIN N3C_COHORT table to be retained
-
---SELECT person_id
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
-SELECT DISTINCT
-    person_id
-FROM final_cohort;
+SELECT DISTINCT person_id
+FROM
+(
+
+/**
+
+INCLUSION:
+
+1) Postive COVID Measurement
+2) Strong positive dx
+3) 2x Weak Dx
+4) COVID Measurement & No occurrences of Z11.59 
+
+
+**/
+
+-- 1) Positive COVID Measurement
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= DATEFROMPARTS(2020, 01, 01)
+	AND (
+		value_as_concept_id IN (
+			4126681,
+			45877985,
+			45884084,
+			9191
+			)
+		OR value_source_value IN (
+			'Positive'
+			,'Present'
+			,'Detected'
+			)
+		)
+
+UNION
+
+-- 2) Strong positive 
+-- prior to 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				260125
+				,260139
+				,46271075
+				,4307774
+				,4195694
+				,257011
+				,442555
+				,4059022
+				,4059021
+				,256451
+				,4059003
+				,4168213
+				,434490
+				,439676
+				,254761
+				,4048098
+				,37311061
+				,4100065
+				,320136
+				,4038519
+				,312437
+				,4060052
+				,4263848
+				,37311059
+				,37016200
+				,4011766
+				,437663
+				,4141062
+				,4164645
+				,4047610
+				,4260205
+				,4185711
+				,4289517
+				,4140453
+				,4090569
+				,4109381
+				,4330445
+				,255848
+				,4102774
+				,436235
+				,261326
+				,320651
+				)
+		)
+	AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
+		AND DATEFROMPARTS(2020, 03, 31)
+
+UNION
+
+-- after 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @vocabulary_database_schema.CONCEPT c
+		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+			AND c.invalid_reason IS NULL
+		)
+	AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
+
+UNION
+
+-- 3) 2x Weak diagnosis 
+-- prior to 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
+			AND DATEFROMPARTS(2020, 03, 31)
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN DATEFROMPARTS(2020, 01, 01)
+			AND DATEFROMPARTS(2020, 03, 31)
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- after 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= DATEFROMPARTS(2020, 04, 01)
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- 4) COVID Measurement & No occurrences of Z11.59 
+-- COVID lab test of any result
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= DATEFROMPARTS(2020, 01, 01)
+	-- existence of Z11.59
+	AND person_id NOT IN (
+		SELECT person_id
+		FROM @cdmDatabaseSchema.OBSERVATION
+		WHERE observation_source_concept_id = 45595484
+			AND observation_date >= DATEFROMPARTS(2020, 04, 01)
+		)
+		
+		
+) 
+;
+
+
 
 INSERT INTO @resultsDatabaseSchema.phenotype_execution
 SELECT
@@ -916,19 +584,3 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
 
-/**Dropping out all the temp tables.**/
-
-TRUNCATE TABLE #cohort_rows;
-DROP TABLE #cohort_rows;
-
-TRUNCATE TABLE #inclusion_events;
-DROP TABLE #inclusion_events;
-
-TRUNCATE TABLE #qualified_events;
-DROP TABLE #qualified_events;
-
-TRUNCATE TABLE #included_events;
-DROP TABLE #included_events;
-
-TRUNCATE TABLE #Codesets;
-DROP TABLE #Codesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
@@ -1,5 +1,5 @@
 /**
-Change log:
+CHANGE LOG:
 V1.1 - initial commit
 V1.2 - updated possible positive cases (typo in name of concept set name) and added additional NIH VSAC codeset_id
 V1.3 - consolidated to single cohort definition and added N3C COHORT table + labeling statements
@@ -11,17 +11,18 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
-incremental change on 10-29: simplified script
+Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
-To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+HOW TO RUN:
+You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-Harmonization note:
-In OHDSI conventions, we do not usually write tables to the main database schema.
-NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+USER NOTES: 
+In OHDSI conventions, we do not usually write tables to the main database schema. 
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
-
-Begin building cohort following OHDSI standard cohort definition process
-
+SCRIPT RELEASE DATE: 11-05-2020
 
 **/
 
@@ -55,6 +56,7 @@ EXCEPTION
 END;
 
 -- Create dest table
+-- Here we need to know when you ran the phenotype, what version you're using and what vocabulary version you've built your OMOP concepts on
 CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	run_datetime TIMESTAMP NOT NULL,
 	phenotype_version varchar(50) NOT NULL,
@@ -68,6 +70,7 @@ FROM (SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
     WHERE measurement_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		    WHERE concept_id IN (
 				586515
 				,586522
@@ -114,17 +117,26 @@ FROM @cdmDatabaseSchema.MEASUREMENT
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		 )
+	-- Here we add a date restriction: after January 1, 2020
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 	AND (
+	-- The value_as_concept field is where we store standardized qualitative results
+	-- The concept ids here represent LOINC or SNOMED codes for standard ways to code a lab that is positive
 		value_as_concept_id IN (
-			4126681,
-			45877985,
-			45884084,
-			9191
+			45878583
+			,37079494
+			,1177295
+			,36307756
+			,36309158
+			,36308436
+			,9189
 			)
+	-- To be exhaustive, we also look for Positive strings in the value_source_value field
 		OR value_source_value IN (
 			'Positive'
 			,'Present'
@@ -134,86 +146,50 @@ FROM @cdmDatabaseSchema.MEASUREMENT
 
    UNION
 
--- 2) Strong positive 
--- prior to 04-01
+-- Phenotype Entry Criteria: ONE or more of the â€œStrong Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables
+-- This section constructs entry logic prior to the CDC guidance issued on April 1, 2020
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
   WHERE condition_concept_id IN (SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 		  WHERE concept_id IN (
-				260125
-				,260139
-				,46271075
-				,4307774
-				,4195694
-				,257011
-				,442555
-				,4059022
-				,4059021
-				,256451
-				,4059003
-				,4168213
-				,434490
-				,439676
-				,254761
-				,4048098
-				,37311061
-				,4100065
-				,320136
-				,4038519
-				,312437
-				,4060052
-				,4263848
-				,37311059
-				,37016200
-				,4011766
-				,437663
-				,4141062
-				,4164645
-				,4047610
-				,4260205
-				,4185711
-				,4289517
-				,4140453
-				,4090569
-				,4109381
-				,4330445
-				,255848
-				,4102774
-				,436235
-				,261326
-				,320651
-				)
+			756023,
+			756044,
+			756061,
+			756031,
+			37311061,
+			756081,
+			37310285,
+			756039,
+			320651,
+			37311060
+			)
 		 )
+	-- This logic imposes the restriction: these codes were only valid as Strong Positive codes between January 1, 2020 and March 31, 2020
 	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 		AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
 
    UNION
 
--- after 04-01
+-- The CDC issued guidance on April 1, 2020 that changed COVID coding conventions
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
   WHERE condition_concept_id IN (SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- This is the list of standard concepts that represent those terms
 		    WHERE concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				37311061,
+				37311060,
+				756023,
+				756031,
+				756039,
+				756044,
+				756061,
+				756081,
+				37310285
 				)
 		
 		   UNION
@@ -221,88 +197,117 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 		SELECT c.concept_id
 		FROM @vocabulary_database_schema.CONCEPT c
 		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				756044,
+				37310285,
+				37310283,
+				756061,
+				756081,
+				37310287,
+				756023,
+				756031,
+				37310286,
+				37311061,
+				37310284,
+				756039,
+				37311060,
+				37310254
 				)
 			AND c.invalid_reason IS NULL
 		 )
+	
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 
    UNION
 
--- 3) 2x Weak diagnosis 
--- prior to 04-01
--- same visit 
+-- 3) TWO or more of the â€œWeak Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables (below) during the same encounter or on the same date
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same date
+-- BEFORE 04-01-2020 "WEAK POSITIVE" LOGIC:
 SELECT DISTINCT person_id
 FROM (SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 			  WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			 )
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
 	GROUP BY person_id
 		,visit_occurrence_id
 	HAVING count(*) >= 2
@@ -310,58 +315,88 @@ FROM (SELECT person_id
 
   UNION
 
--- same date
+-- Now we apply logic to look for same visit AND same date
 SELECT DISTINCT person_id
 FROM (SELECT person_id
-		,condition_start_date
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			  WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			 )
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
 	GROUP BY person_id
@@ -371,15 +406,109 @@ FROM (SELECT person_id
 
   UNION
 
--- after 04-01
--- same visit 
+-- AFTER 04-01-2020 "WEAK POSITIVE" LOGIC:
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same visit
+
 SELECT DISTINCT person_id
 FROM (SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
+			  WHERE concept_id IN (
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971,
+					320651
+					)
+			 )
+	-- This code list is only valid for CDC guidance before 04-01-2020
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	 ) dx_same_encounter
+
+  UNION
+
+-- Now we apply logic to look for same visit AND same date
+SELECT DISTINCT person_id
+FROM (SELECT person_id
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	  WHERE condition_concept_id IN (SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those term
 			  WHERE concept_id IN (
 					260125
 					,260139
@@ -425,81 +554,26 @@ FROM (SELECT person_id
 					,320651
 					)
 			 )
+		-- This code list is based on CDC Guidance for code use AFTER 04-01-2020
 		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-	GROUP BY person_id
-		,visit_occurrence_id
-	HAVING count(*) >= 2
-	 ) dx_same_encounter
-
-  UNION
-
--- same date
-SELECT DISTINCT person_id
-FROM (SELECT person_id
-		,condition_start_date
-		,count(*)
-	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-	  WHERE condition_concept_id IN (SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
-			  WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
-					,320651
-					)
-			 )
-		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-	GROUP BY person_id
+-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
 		,condition_start_date
 	HAVING count(*) >= 2
 	 ) dx_same_date
 
   UNION
 
--- 4) COVID Measurement & No occurrences of Z11.59 
--- COVID lab test of any result
+-- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
+
+-- We begin by looking for ANY COVID measurement
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		    WHERE concept_id IN (
 				586515
 				,586522
@@ -546,11 +620,15 @@ WHERE measurement_concept_id IN (SELECT concept_id
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		 )
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 	-- existence of Z11.59
+	-- Z11.59 here is being pulled from the source_concept_id
+	-- we want to make extra sure that we're ONLY looking at Z11.59 not the more general SNOMED code that would be in the standard concept id column for this
 	AND person_id NOT IN (SELECT person_id
 		FROM @cdmDatabaseSchema.OBSERVATION
 		  WHERE observation_source_concept_id = 45595484
@@ -567,4 +645,3 @@ INSERT INTO @resultsDatabaseSchema.phenotype_execution
 SELECT SYSDATE as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT vocabulary_version FROM @cdmDatabaseSchema.vocabulary    WHERE vocabulary_id='None'   AND ROWNUM <= 1) AS VOCABULARY_VERSION FROM DUAL;
-

--- a/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
@@ -11,6 +11,7 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
+incremental change on 10-29: simplified script
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
 
@@ -25,6 +26,7 @@ Begin building cohort following OHDSI standard cohort definition process
 **/
 
 /** Creating the N3C Cohort table **/
+
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 BEGIN
   EXECUTE IMMEDIATE 'TRUNCATE TABLE @resultsDatabaseSchema.n3c_cohort';
@@ -60,711 +62,509 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 );
 
 
--- OHDSI ATLAS generated cohort logic
-/** This block of code generates concept sets to be used in this phenotype**/
-CREATE TABLE cxk18wbkCodesets (
-  codeset_id int NOT NULL,
-  concept_id NUMBER(19) NOT NULL
-)
-;
-
-/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
-In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-SELECT 0 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
-   UNION  select c.concept_id
-  FROM @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756055)
-  and c.invalid_reason is null
-
- ) I
- ) C ;
-/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-SELECT 2 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
-
- ) I
- ) C ;
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-SELECT 3 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-   UNION  select c.concept_id
-  FROM @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-  and c.invalid_reason is null
-
- ) I
- ) C ;
-/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-/
-SELECT 4 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-   UNION  select c.concept_id
-  FROM @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-  and c.invalid_reason is null
-
- ) I
- ) C ;
-/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-SELECT 5 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
-
- ) I
- ) C ;
-/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
-The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
-You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
-INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
-SELECT 6 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (45595484)
-
- ) I
- ) C ;
-
-/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
-It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
-In the case of N3C, we don't impart any rules here.**/
-CREATE TABLE cxk18wbkqualified_events
-
-AS
-WITH primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id)  AS (SELECT P.ordinal as event_id, P.person_id, P.start_date, P.end_date, op_start_date, op_end_date, cast(P.visit_occurrence_id as NUMBER(19)) as visit_occurrence_id
-FROM (SELECT E.person_id, E.start_date, E.end_date,
-         row_number() OVER (PARTITION BY E.person_id ORDER BY E.sort_date ASC) ordinal,
-         OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as NUMBER(19)) as visit_occurrence_id
-  FROM (SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-FROM (SELECT m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
- ) C
-
-    WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
- AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
- OR
- C.value_source_value in ('Positive', 'Present', 'Detected')
- ) **/
- -- End Measurement Criteria
-
-   UNION ALL
-/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
-
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id  event_id, C.condition_start_date  start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
- ) C
-
-   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-   UNION ALL
-
-/**The next code is saying to look for a strong positive on or after 04-01-2020**/
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id  event_id, C.condition_start_date  start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
- ) C
-
-   WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
-   UNION ALL
-/**The next code is saying to look for a Weak Positive before 04-01-2020**/
-SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
- ) C
-
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
- ) PE
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
-It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
-AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
-It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
-JOIN (SELECT 0 as index_id, person_id, event_id
-FROM (SELECT E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
- ) C
-/* This code tells it what dates: before 04-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) E
-  INNER JOIN
-  (SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
- ) C
-/** This code tells it what dates: before 04-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER JOIN
-(SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
- ) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + NUMTODSINTERVAL(0, 'day')) AND A.START_DATE <= (P.START_DATE + NUMTODSINTERVAL(0, 'day'))
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
- ) G
--- End Criteria Group
- ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
-
-  UNION ALL
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
-SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
- ) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
- ) PE
-JOIN (SELECT 0 as index_id, person_id, event_id
-FROM (SELECT E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
- ) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) E
-  INNER JOIN
-  (SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
- ) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER JOIN
-/**OCCURRENCE 2**/
-(SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
- ) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + NUMTODSINTERVAL(0, 'day')) AND A.START_DATE <= (P.START_DATE + NUMTODSINTERVAL(0, 'day'))
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
- ) G
--- End Criteria Group
- ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
-
-  UNION ALL
-/**We have to now apply logic to look for Asymptomatic patients.
-This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
-Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
-It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
-So we start by building a piece of logic to look at the OBSERVATION domain.**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-FROM (SELECT o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
- ) C
-/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
-  WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-
- ) PE
-JOIN (SELECT 0 as index_id, person_id, event_id
-FROM (SELECT E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-FROM (SELECT o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
- ) C
-
-  WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) E
-  INNER JOIN
-  (SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-FROM (SELECT o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
- ) C
-
-  WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER JOIN
-/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-(SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
- ) C
-/**This is where we impart the date rule: on or after 04-01-2020**/
-  WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
- ) PE
-JOIN (SELECT 0 as index_id, person_id, event_id
-FROM (SELECT E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
- ) C
-/**We add the date criteria: on or after 04-01-2020**/
-  WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
- ) Q
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) E
-  LEFT JOIN
-  (SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
- ) C
-
-  WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
-INNER JOIN
-(SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-FROM (SELECT m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
- ) C
-/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
-In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
-  WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-   ) 
-  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
-  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
- ) G
--- End Criteria Group
- ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  UNION ALL
--- Begin Correlated Criteria
-
-/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
-/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
-SELECT 1  index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-FROM (SELECT o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
- ) C
-
-  WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER 
-/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-(SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
- ) C
-/**Restricting to after 01-01-2020 and before 04-01-2020**/
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
- ) PE
-JOIN (SELECT 0 as index_id, person_id, event_id
-FROM (SELECT E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
- ) C
-
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) E
-  LEFT JOIN
-  (SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM (SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
- ) C
-
-  WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER JOIN
-/*Now we specifiy the logic to look for a lab-confirmed negative.*/
-(SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-FROM (SELECT m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
- ) C
-/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
-  WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
-   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
- ) G
--- End Criteria Group
- ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  UNION ALL
-/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
-/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
--- Begin Correlated Criteria
-SELECT 2  index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-FROM (SELECT o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
- ) C
-/**Restricting to after 04-01-2020**/
-  WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
- ) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
- ) P
-INNER JOIN
-/**Looking in the Measurement table for lab-confirmed positive**/
-(SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-FROM (SELECT m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
- ) C
-/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
-This is where the logic from MS SQL Line 159-163 should have gone.**/
-  WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-OR
-C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
-
-
--- End Measurement Criteria
-/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
- ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) >= 1
- ) G
--- End Criteria Group
- ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-   ) E
-	JOIN @cdmDatabaseSchema.observation_period OP on E.person_id = OP.person_id and E.start_date >=  OP.observation_period_start_date and E.start_date <= op.observation_period_end_date
-    WHERE (OP.OBSERVATION_PERIOD_START_DATE + NUMTODSINTERVAL(0, 'day')) <= E.START_DATE AND (E.START_DATE + NUMTODSINTERVAL(0, 'day')) <= OP.OBSERVATION_PERIOD_END_DATE
- ) P
-  WHERE P.ordinal = 1
--- End Primary Events
-
- ) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
- SELECT
-event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
-
-FROM
-(SELECT pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date ASC) as ordinal, cast(pe.visit_occurrence_id as NUMBER(19)) as visit_occurrence_id
-  FROM primary_events pe
-  
- ) QE
-
- ;
-
-/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
-
---- Inclusion Rule Inserts
-
-create table cxk18wbkinclusion_events (inclusion_rule_id NUMBER(19),
-	person_id NUMBER(19),
-	event_id NUMBER(19)
-);
-
-CREATE TABLE cxk18wbkincluded_events
-
-AS
-WITH cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal)  AS (SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, row_number() over (partition by person_id order by start_date ASC) as ordinal
-  FROM (SELECT Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as NUMBER(19)), I.inclusion_rule_id), 0)) as inclusion_rule_mask
-    FROM cxk18wbkqualified_events Q
-    LEFT JOIN cxk18wbkinclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
-    GROUP BY Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date
-   ) MG -- matching groups
-
- )
- SELECT
-event_id, person_id, start_date, end_date, op_start_date, op_end_date
-
-FROM
-cteIncludedEvents Results
-  WHERE Results.ordinal = 1
- ;
-
-
-/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
--- generate cohort periods into #final_cohort
-CREATE TABLE cxk18wbkcohort_rows
-
-AS
-WITH cohort_ends (event_id, person_id, end_date)  AS (SELECT event_id, person_id, op_end_date as end_date FROM cxk18wbkincluded_events
- ),
-first_ends (person_id, start_date, end_date) as
-(SELECT F.person_id, F.start_date, F.end_date
-	FROM (SELECT I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
-	  FROM cxk18wbkincluded_events I
-	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
-	 ) F
-	  WHERE F.ordinal = 1
- )
- SELECT
-person_id, start_date, end_date
-
-FROM
-first_ends ;
-
-/**More Atlas generated code that largely goes unused.**/
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
- WITH cteEndDates (person_id, end_date)  AS (SELECT person_id
-		, (event_date + NUMTODSINTERVAL(-1 * 0, 'day'))  as end_date
-	FROM (SELECT person_id
-			, event_date
-			, event_type
-			, MAX(start_ordinal) OVER (PARTITION BY person_id ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal 
-			, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY event_date, event_type) AS overall_ord
-		FROM (SELECT person_id
-				, start_date AS event_date
-				, -1 AS event_type
-				, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date) AS start_ordinal
-			FROM cxk18wbkcohort_rows
+SELECT DISTINCT person_id
+FROM (SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+    WHERE measurement_concept_id IN (SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		    WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
 		
-			  UNION ALL
+		   UNION
 		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		 )
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	AND (
+		value_as_concept_id IN (
+			4126681,
+			45877985,
+			45884084,
+			9191
+			)
+		OR value_source_value IN (
+			'Positive'
+			,'Present'
+			,'Detected'
+			)
+		)
 
-			SELECT
-				person_id
-				, (end_date + NUMTODSINTERVAL(0, 'day'))  end_date
-				, 1 AS event_type
-				, NULL
-			FROM cxk18wbkcohort_rows
-		 ) RAWDATA
-	 ) e
-	  WHERE (2 * e.start_ordinal) - e.overall_ord = 0
- ),
-cteEnds (person_id, start_date, end_date) AS
-(SELECT c.person_id
-		, c.start_date
-		, MIN(e.end_date) AS end_date
-	FROM cxk18wbkcohort_rows c
-	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
-	GROUP BY c.person_id, c.start_date
- ),
-final_cohort (person_id, start_date, end_date) AS
-(SELECT person_id, min(start_date) as start_date, end_date
-FROM cteEnds
-group by person_id, end_date
- )
+   UNION
 
-/**The final collapsing of ALL the logic into the cohort table.**/
---# BEGIN N3C_COHORT table to be retained
+-- 2) Strong positive 
+-- prior to 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+  WHERE condition_concept_id IN (SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		  WHERE concept_id IN (
+				260125
+				,260139
+				,46271075
+				,4307774
+				,4195694
+				,257011
+				,442555
+				,4059022
+				,4059021
+				,256451
+				,4059003
+				,4168213
+				,434490
+				,439676
+				,254761
+				,4048098
+				,37311061
+				,4100065
+				,320136
+				,4038519
+				,312437
+				,4060052
+				,4263848
+				,37311059
+				,37016200
+				,4011766
+				,437663
+				,4141062
+				,4164645
+				,4047610
+				,4260205
+				,4185711
+				,4289517
+				,4140453
+				,4090569
+				,4109381
+				,4330445
+				,255848
+				,4102774
+				,436235
+				,261326
+				,320651
+				)
+		 )
+	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+		AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
 
---SELECT person_id
- SELECT DISTINCT
-    person_id
-FROM final_cohort ;
+   UNION
+
+-- after 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+  WHERE condition_concept_id IN (SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		    WHERE concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+		
+		   UNION
+		
+		SELECT c.concept_id
+		FROM @vocabulary_database_schema.CONCEPT c
+		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+			AND c.invalid_reason IS NULL
+		 )
+	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+
+   UNION
+
+-- 3) 2x Weak diagnosis 
+-- prior to 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	  WHERE condition_concept_id IN (SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			  WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			 )
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	 ) dx_same_encounter
+
+  UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	  WHERE condition_concept_id IN (SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			  WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			 )
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	 ) dx_same_date
+
+  UNION
+
+-- after 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	  WHERE condition_concept_id IN (SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			  WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			 )
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	 ) dx_same_encounter
+
+  UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	  WHERE condition_concept_id IN (SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			  WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			 )
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	 ) dx_same_date
+
+  UNION
+
+-- 4) COVID Measurement & No occurrences of Z11.59 
+-- COVID lab test of any result
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		    WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		   UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		 )
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	-- existence of Z11.59
+	AND person_id NOT IN (SELECT person_id
+		FROM @cdmDatabaseSchema.OBSERVATION
+		  WHERE observation_source_concept_id = 45595484
+			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+		 )
+		
+		
+ ) 
+ ;
+
+
 
 INSERT INTO @resultsDatabaseSchema.phenotype_execution
 SELECT SYSDATE as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT vocabulary_version FROM @cdmDatabaseSchema.vocabulary    WHERE vocabulary_id='None'   AND ROWNUM <= 1) AS VOCABULARY_VERSION FROM DUAL;
 
-/**Dropping out all the temp tables.**/
-
-TRUNCATE TABLE cxk18wbkcohort_rows;
-DROP TABLE cxk18wbkcohort_rows;
-
-TRUNCATE TABLE cxk18wbkinclusion_events;
-DROP TABLE cxk18wbkinclusion_events;
-
-TRUNCATE TABLE cxk18wbkqualified_events;
-DROP TABLE cxk18wbkqualified_events;
-
-TRUNCATE TABLE cxk18wbkincluded_events;
-DROP TABLE cxk18wbkincluded_events;
-
-TRUNCATE TABLE cxk18wbkCodesets;
-DROP TABLE cxk18wbkCodesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
@@ -10,17 +10,10 @@ V2.0 - dropping weak diagnosis after May 1, adding asymptomatic test code (Z11.5
 changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
-
-Instructions:
-Cohorts were assembled using OHDSI Atlas (atlas-covid19.ohdsi.org)
-This MS SQL script is the artifact of this ATLAS cohort definition: http://atlas-covid19.ohdsi.org/#/cohortdefinition/1119
-If desired to evaluate feasibility of each cohort, individual cohorts are available:
-1- Lab-confirmed positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/655)
-2- Lab-confirmed negative cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/656)
-3- Suspected positive cases	(http://atlas-covid19.ohdsi.org/#/cohortdefinition/657)
-4- Possible positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/658)
+V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+
 Harmonization note:
 In OHDSI conventions, we do not usually write tables to the main database schema.
 NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
@@ -31,6 +24,7 @@ Begin building cohort following OHDSI standard cohort definition process
 
 **/
 
+/** Creating the N3C Cohort table **/
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 BEGIN
   EXECUTE IMMEDIATE 'TRUNCATE TABLE @resultsDatabaseSchema.n3c_cohort';
@@ -65,14 +59,18 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	vocabulary_version varchar(50) NULL
 );
 
+
 -- OHDSI ATLAS generated cohort logic
-CREATE TABLE km5ggeyvCodesets (
+/** This block of code generates concept sets to be used in this phenotype**/
+CREATE TABLE cxk18wbkCodesets (
   codeset_id int NOT NULL,
   concept_id NUMBER(19) NOT NULL
 )
 ;
 
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
+In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
 SELECT 0 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
    UNION  select c.concept_id
   FROM @cdmDatabaseSchema.CONCEPT c
@@ -82,12 +80,18 @@ SELECT 0 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SE
 
  ) I
  ) C ;
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
 SELECT 2 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
 
  ) I
  ) C ;
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 SELECT 3 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
    UNION  select c.concept_id
   FROM @cdmDatabaseSchema.CONCEPT c
@@ -97,7 +101,11 @@ SELECT 3 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SE
 
  ) I
  ) C ;
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
+/
 SELECT 4 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT     WHERE concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
    UNION  select c.concept_id
   FROM @cdmDatabaseSchema.CONCEPT c
@@ -107,19 +115,27 @@ SELECT 4 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SE
 
  ) I
  ) C ;
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
 SELECT 5 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
 
  ) I
  ) C ;
-INSERT INTO km5ggeyvCodesets (codeset_id, concept_id)
+/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
+The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
+You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
+INSERT INTO cxk18wbkCodesets (codeset_id, concept_id)
 SELECT 6 as codeset_id, c.concept_id FROM (SELECT distinct I.concept_id FROM (SELECT concept_id FROM @cdmDatabaseSchema.CONCEPT   WHERE concept_id in (45595484)
 
  ) I
  ) C ;
 
-
-CREATE TABLE km5ggeyvqualified_events
+/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
+It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
+In the case of N3C, we don't impart any rules here.**/
+CREATE TABLE cxk18wbkqualified_events
 
 AS
 WITH primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id)  AS (SELECT P.ordinal as event_id, P.person_id, P.start_date, P.end_date, op_start_date, op_end_date, cast(P.visit_occurrence_id as NUMBER(19)) as visit_occurrence_id
@@ -131,55 +147,65 @@ FROM (SELECT E.person_id, E.start_date, E.end_date,
        C.measurement_date as sort_date
 FROM (SELECT m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN km5ggeyvCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
  ) C
 
     WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-	OR
-	C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
--- End Measurement Criteria
+/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
+ AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+ OR
+ C.value_source_value in ('Positive', 'Present', 'Detected')
+ ) **/
+ -- End Measurement Criteria
 
    UNION ALL
+/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
+
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id  event_id, C.condition_start_date  start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
  ) C
 
    WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
    UNION ALL
+
+/**The next code is saying to look for a strong positive on or after 04-01-2020**/
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id  event_id, C.condition_start_date  start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
  ) C
 
    WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 
    UNION ALL
+/**The next code is saying to look for a Weak Positive before 04-01-2020**/
 SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
  ) C
 
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
  ) PE
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
+It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
+AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
+It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
 JOIN (SELECT 0 as index_id, person_id, event_id
 FROM (SELECT E.person_id, E.event_id 
   FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -188,9 +214,9 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
  ) C
-
+/* This code tells it what dates: before 04-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
  ) Q
@@ -205,9 +231,9 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
  ) C
-
+/** This code tells it what dates: before 04-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
  ) Q
@@ -220,33 +246,36 @@ INNER JOIN
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
  ) C
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
  ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + NUMTODSINTERVAL(0, 'day')) AND A.START_DATE <= (P.START_DATE + NUMTODSINTERVAL(0, 'day'))
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
    ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
  ) G
 -- End Criteria Group
  ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
 
   UNION ALL
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
 SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
  ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
@@ -259,9 +288,9 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
  ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
  ) Q
@@ -276,9 +305,9 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
  ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
  ) Q
@@ -286,38 +315,45 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
 INNER JOIN
+/**OCCURRENCE 2**/
 (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
  ) C
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
  ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + NUMTODSINTERVAL(0, 'day')) AND A.START_DATE <= (P.START_DATE + NUMTODSINTERVAL(0, 'day'))
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
    ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
  ) G
 -- End Criteria Group
  ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
 
   UNION ALL
+/**We have to now apply logic to look for Asymptomatic patients.
+This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
+Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
+It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
+So we start by building a piece of logic to look at the OBSERVATION domain.**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
        C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.observation_date as sort_date
 FROM (SELECT o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
  ) C
-
+/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
   WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Observation Criteria
 
@@ -330,7 +366,7 @@ FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as st
        C.observation_date as sort_date
 FROM (SELECT o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
  ) C
 
   WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
@@ -347,7 +383,7 @@ FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as st
        C.observation_date as sort_date
 FROM (SELECT o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
  ) C
 
   WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
@@ -357,14 +393,15 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
 INNER JOIN
+/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 (SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
  ) C
-
+/**This is where we impart the date rule: on or after 04-01-2020**/
   WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 
@@ -377,12 +414,15 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
  ) C
-
+/**We add the date criteria: on or after 04-01-2020**/
   WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
  ) Q
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) E
@@ -394,7 +434,7 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
  ) C
 
   WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
@@ -403,30 +443,34 @@ FROM (SELECT co.*
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
+/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
 INNER JOIN
 (SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 FROM (SELECT m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN km5ggeyvCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
  ) C
-
+/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
+In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
   WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
-
+/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
  ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
-   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
+   ) 
+  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
+  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
  ) G
 -- End Criteria Group
  ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
+/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
  ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -434,6 +478,9 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 
   UNION ALL
 -- Begin Correlated Criteria
+
+/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
+/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
 SELECT 1  index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
 FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
@@ -441,7 +488,7 @@ FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as st
        C.observation_date as sort_date
 FROM (SELECT o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
  ) C
 
   WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
@@ -450,15 +497,18 @@ JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.c
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
-INNER JOIN
+INNER 
+/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 (SELECT PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + NUMTODSINTERVAL(1, 'day'))) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
  ) C
-
+/**Restricting to after 01-01-2020 and before 04-01-2020**/
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
@@ -471,7 +521,7 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
  ) C
 
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
@@ -488,7 +538,7 @@ FROM (SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_sta
        C.condition_start_date as sort_date
 FROM (SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN km5ggeyvCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
+  JOIN cxk18wbkCodesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
  ) C
 
   WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
@@ -498,14 +548,15 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
 INNER JOIN
+/*Now we specifiy the logic to look for a lab-confirmed negative.*/
 (SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 FROM (SELECT m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN km5ggeyvCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
  ) C
-
+/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
   WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
 
@@ -513,7 +564,7 @@ JOIN km5ggeyvCodesets codesets on ((m.measurement_concept_id = codesets.concept_
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
-
+/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
    ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
@@ -527,6 +578,8 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
   UNION ALL
+/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
+/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
 -- Begin Correlated Criteria
 SELECT 2  index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -535,9 +588,9 @@ FROM (SELECT C.person_id, C.observation_id as event_id, C.observation_date as st
        C.observation_date as sort_date
 FROM (SELECT o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN km5ggeyvCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
+JOIN cxk18wbkCodesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
  ) C
-
+/**Restricting to after 04-01-2020**/
   WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Observation Criteria
  ) Q
@@ -545,17 +598,24 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
  ) P
 INNER JOIN
+/**Looking in the Measurement table for lab-confirmed positive**/
 (SELECT C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + NUMTODSINTERVAL(1, 'day')) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 FROM (SELECT m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN km5ggeyvCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
+JOIN cxk18wbkCodesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
  ) C
+/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
+This is where the logic from MS SQL Line 159-163 should have gone.**/
+  WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+OR
+C.value_source_value in ('Positive', 'Present', 'Detected')
+	)
 
-  WHERE C.value_as_concept_id in (4126681,45877985,45884084,9191)
+
 -- End Measurement Criteria
-
+/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
  ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -575,7 +635,7 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
   WHERE P.ordinal = 1
 -- End Primary Events
 
- )
+ ) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
  SELECT
 event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 
@@ -587,20 +647,22 @@ FROM
 
  ;
 
+/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
+
 --- Inclusion Rule Inserts
 
-create table km5ggeyvinclusion_events (inclusion_rule_id NUMBER(19),
+create table cxk18wbkinclusion_events (inclusion_rule_id NUMBER(19),
 	person_id NUMBER(19),
 	event_id NUMBER(19)
 );
 
-CREATE TABLE km5ggeyvincluded_events
+CREATE TABLE cxk18wbkincluded_events
 
 AS
 WITH cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal)  AS (SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, row_number() over (partition by person_id order by start_date ASC) as ordinal
   FROM (SELECT Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as NUMBER(19)), I.inclusion_rule_id), 0)) as inclusion_rule_mask
-    FROM km5ggeyvqualified_events Q
-    LEFT JOIN km5ggeyvinclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
+    FROM cxk18wbkqualified_events Q
+    LEFT JOIN cxk18wbkinclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
     GROUP BY Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date
    ) MG -- matching groups
 
@@ -614,17 +676,17 @@ cteIncludedEvents Results
  ;
 
 
-
+/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
 -- generate cohort periods into #final_cohort
-CREATE TABLE km5ggeyvcohort_rows
+CREATE TABLE cxk18wbkcohort_rows
 
 AS
-WITH cohort_ends (event_id, person_id, end_date)  AS (SELECT event_id, person_id, op_end_date as end_date FROM km5ggeyvincluded_events
+WITH cohort_ends (event_id, person_id, end_date)  AS (SELECT event_id, person_id, op_end_date as end_date FROM cxk18wbkincluded_events
  ),
 first_ends (person_id, start_date, end_date) as
 (SELECT F.person_id, F.start_date, F.end_date
 	FROM (SELECT I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
-	  FROM km5ggeyvincluded_events I
+	  FROM cxk18wbkincluded_events I
 	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
 	 ) F
 	  WHERE F.ordinal = 1
@@ -635,6 +697,7 @@ person_id, start_date, end_date
 FROM
 first_ends ;
 
+/**More Atlas generated code that largely goes unused.**/
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
  WITH cteEndDates (person_id, end_date)  AS (SELECT person_id
 		, (event_date + NUMTODSINTERVAL(-1 * 0, 'day'))  as end_date
@@ -647,7 +710,7 @@ INSERT INTO @resultsDatabaseSchema.n3c_cohort
 				, start_date AS event_date
 				, -1 AS event_type
 				, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date) AS start_ordinal
-			FROM km5ggeyvcohort_rows
+			FROM cxk18wbkcohort_rows
 		
 			  UNION ALL
 		
@@ -657,7 +720,7 @@ INSERT INTO @resultsDatabaseSchema.n3c_cohort
 				, (end_date + NUMTODSINTERVAL(0, 'day'))  end_date
 				, 1 AS event_type
 				, NULL
-			FROM km5ggeyvcohort_rows
+			FROM cxk18wbkcohort_rows
 		 ) RAWDATA
 	 ) e
 	  WHERE (2 * e.start_ordinal) - e.overall_ord = 0
@@ -666,7 +729,7 @@ cteEnds (person_id, start_date, end_date) AS
 (SELECT c.person_id
 		, c.start_date
 		, MIN(e.end_date) AS end_date
-	FROM km5ggeyvcohort_rows c
+	FROM cxk18wbkcohort_rows c
 	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
 	GROUP BY c.person_id, c.start_date
  ),
@@ -676,6 +739,7 @@ FROM cteEnds
 group by person_id, end_date
  )
 
+/**The final collapsing of ALL the logic into the cohort table.**/
 --# BEGIN N3C_COHORT table to be retained
 
 --SELECT person_id
@@ -688,18 +752,19 @@ SELECT SYSDATE as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT vocabulary_version FROM @cdmDatabaseSchema.vocabulary    WHERE vocabulary_id='None'   AND ROWNUM <= 1) AS VOCABULARY_VERSION FROM DUAL;
 
+/**Dropping out all the temp tables.**/
 
-TRUNCATE TABLE km5ggeyvcohort_rows;
-DROP TABLE km5ggeyvcohort_rows;
+TRUNCATE TABLE cxk18wbkcohort_rows;
+DROP TABLE cxk18wbkcohort_rows;
 
-TRUNCATE TABLE km5ggeyvinclusion_events;
-DROP TABLE km5ggeyvinclusion_events;
+TRUNCATE TABLE cxk18wbkinclusion_events;
+DROP TABLE cxk18wbkinclusion_events;
 
-TRUNCATE TABLE km5ggeyvqualified_events;
-DROP TABLE km5ggeyvqualified_events;
+TRUNCATE TABLE cxk18wbkqualified_events;
+DROP TABLE cxk18wbkqualified_events;
 
-TRUNCATE TABLE km5ggeyvincluded_events;
-DROP TABLE km5ggeyvincluded_events;
+TRUNCATE TABLE cxk18wbkincluded_events;
+DROP TABLE cxk18wbkincluded_events;
 
-TRUNCATE TABLE km5ggeyvCodesets;
-DROP TABLE km5ggeyvCodesets;
+TRUNCATE TABLE cxk18wbkCodesets;
+DROP TABLE cxk18wbkCodesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
@@ -14,7 +14,7 @@ V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes a
 Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
 HOW TO RUN:
-You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
+You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
 USER NOTES: 
 In OHDSI conventions, we do not usually write tables to the main database schema. 
@@ -151,7 +151,7 @@ FROM @cdmDatabaseSchema.MEASUREMENT
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
   WHERE condition_concept_id IN (SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
 		  WHERE concept_id IN (
@@ -177,7 +177,7 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
   WHERE condition_concept_id IN (SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
 		    WHERE concept_id IN (
@@ -195,8 +195,8 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 		   UNION
 		
 		SELECT c.concept_id
-		FROM @vocabulary_database_schema.CONCEPT c
-		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
 		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
 				756044,
@@ -228,7 +228,7 @@ SELECT DISTINCT person_id
 FROM (SELECT person_id
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -320,7 +320,7 @@ SELECT DISTINCT person_id
 FROM (SELECT person_id
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -413,7 +413,7 @@ SELECT DISTINCT person_id
 FROM (SELECT person_id
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -505,7 +505,7 @@ SELECT DISTINCT person_id
 FROM (SELECT person_id
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	  WHERE condition_concept_id IN (SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those term

--- a/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_oracle.sql
@@ -16,9 +16,9 @@ Script changes between 10-29 & 11-05: simplified script to human-written SQL (ve
 HOW TO RUN:
 You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-USER NOTES: 
-In OHDSI conventions, we do not usually write tables to the main database schema. 
-OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+USER NOTES:
+In OHDSI conventions, we do not usually write tables to the main database schema.
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis.
 We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
 To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
@@ -65,8 +65,8 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 
 
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
+-- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
-FROM (SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
     WHERE measurement_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
@@ -111,9 +111,9 @@ FROM @cdmDatabaseSchema.MEASUREMENT
 				,757686
 				,756055
 				)
-		
+
 		   UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -150,7 +150,7 @@ FROM @cdmDatabaseSchema.MEASUREMENT
 -- This section constructs entry logic prior to the CDC guidance issued on April 1, 2020
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-  WHERE condition_concept_id IN (SELECT concept_id
+    WHERE condition_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -176,7 +176,7 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 -- The CDC issued guidance on April 1, 2020 that changed COVID coding conventions
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-  WHERE condition_concept_id IN (SELECT concept_id
+    WHERE condition_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
@@ -191,9 +191,9 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 				756081,
 				37310285
 				)
-		
+
 		   UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -216,7 +216,7 @@ FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 				)
 			AND c.invalid_reason IS NULL
 		 )
-	
+
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 
    UNION
@@ -323,7 +323,7 @@ FROM (SELECT person_id
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			  WHERE concept_id IN (
 					260125,
 					260139,
@@ -416,7 +416,7 @@ FROM (SELECT person_id
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			  WHERE concept_id IN (
 					260125,
 					260139,
@@ -565,13 +565,13 @@ FROM (SELECT person_id
   UNION
 
 -- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
--- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020,
 -- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
 
 -- We begin by looking for ANY COVID measurement
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
-WHERE measurement_concept_id IN (SELECT concept_id
+          WHERE measurement_concept_id IN (SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
 		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		    WHERE concept_id IN (
@@ -614,9 +614,9 @@ WHERE measurement_concept_id IN (SELECT concept_id
 				,757686
 				,756055
 				)
-		
+
 		   UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -634,10 +634,7 @@ WHERE measurement_concept_id IN (SELECT concept_id
 		  WHERE observation_source_concept_id = 45595484
 			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 		 )
-		
-		
- ) 
- ;
+		               ;
 
 
 

--- a/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
@@ -10,17 +10,10 @@ V2.0 - dropping weak diagnosis after May 1, adding asymptomatic test code (Z11.5
 changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
-
-Instructions:
-Cohorts were assembled using OHDSI Atlas (atlas-covid19.ohdsi.org)
-This MS SQL script is the artifact of this ATLAS cohort definition: http://atlas-covid19.ohdsi.org/#/cohortdefinition/1119
-If desired to evaluate feasibility of each cohort, individual cohorts are available:
-1- Lab-confirmed positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/655)
-2- Lab-confirmed negative cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/656)
-3- Suspected positive cases	(http://atlas-covid19.ohdsi.org/#/cohortdefinition/657)
-4- Possible positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/658)
+V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+
 Harmonization note:
 In OHDSI conventions, we do not usually write tables to the main database schema.
 NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
@@ -31,6 +24,7 @@ Begin building cohort following OHDSI standard cohort definition process
 
 **/
 
+/** Creating the N3C Cohort table **/
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -49,12 +43,16 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	vocabulary_version varchar(50) NULL
 );
 
+
 -- OHDSI ATLAS generated cohort logic
+/** This block of code generates concept sets to be used in this phenotype**/
 CREATE TEMP TABLE Codesets  (codeset_id int NOT NULL,
   concept_id bigint NOT NULL
 )
 ;
 
+/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
+In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
 INSERT INTO Codesets (codeset_id, concept_id)
 SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -67,6 +65,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO Codesets (codeset_id, concept_id)
 SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -75,6 +76,9 @@ SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 INSERT INTO Codesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
@@ -86,7 +90,11 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO Codesets (codeset_id, concept_id)
+/
 SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
@@ -98,6 +106,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 INSERT INTO Codesets (codeset_id, concept_id)
 SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -105,6 +116,9 @@ SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 
 ) I
 ) C;
+/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
+The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
+You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
 INSERT INTO Codesets (codeset_id, concept_id)
 SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -113,7 +127,9 @@ SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 
-
+/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
+It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
+In the case of N3C, we don't impart any rules here.**/
 CREATE TEMP TABLE qualified_events
 
 AS
@@ -127,6 +143,8 @@ FROM
          OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
   FROM 
   (
+/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
+The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -139,18 +157,22 @@ JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and c
 ) C
 
 WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-	OR
-	C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
--- End Measurement Criteria
+/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
+ AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+ OR
+ C.value_source_value in ('Positive', 'Present', 'Detected')
+ ) **/
+ -- End Measurement Criteria
 
 UNION ALL
+/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
+
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**The next code is saying to look for a strong positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -161,6 +183,8 @@ WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'
 -- End Condition Occurrence Criteria
 
 UNION ALL
+
+/**The next code is saying to look for a strong positive on or after 04-01-2020**/
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -176,6 +200,7 @@ WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'0
 -- End Condition Occurrence Criteria
 
 UNION ALL
+/**The next code is saying to look for a Weak Positive before 04-01-2020**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
@@ -192,10 +217,15 @@ WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'
 -- End Condition Occurrence Criteria
 
 ) PE
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
+It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
+AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
+It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
 JOIN (
 -- Begin Criteria Group
 select 0 as index_id, person_id, event_id
 FROM
+/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
 (
   select E.person_id, E.event_id 
   FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -204,12 +234,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/* This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -226,12 +257,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/** This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -245,6 +277,7 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -253,38 +286,44 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + 0*INTERVAL'1 day') AND A.START_DATE <= (P.START_DATE + 0*INTERVAL'1 day')
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
 
 UNION ALL
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**OCCURRENCE 1**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -295,12 +334,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -317,12 +357,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -330,12 +371,14 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**OCCURRENCE 2**/
 (
   -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -344,38 +387,55 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + 0*INTERVAL'1 day') AND A.START_DATE <= (P.START_DATE + 0*INTERVAL'1 day')
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
 
 UNION ALL
+/**We have to now apply logic to look for Asymptomatic patients.
+This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
+Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
+It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
+So we start by building a piece of logic to look at the OBSERVATION domain.**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Observation Criteria
 select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
        C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.observation_date as sort_date
 from 
+/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
 (
   select o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
 WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Observation Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**Here's where things get interesting... we want to restrict Z11.59 to be with:
+At least 1 Strong Positive On or After 04-01-2020
+ --> but not people who have a lab-confirmed negative
+OR
+At least 1 Strong Positive Before 04-01-2020
+ --> but not people who have a lab-confirmed negative
+ OR
+At least 1 Lab-confirmed Positive **/
+
+/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -421,6 +481,7 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -428,18 +489,22 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**This is where we impart the date rule: on or after 04-01-2020**/
 WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -450,15 +515,19 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**We add the date criteria: on or after 04-01-2020**/
 WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 ) Q
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) E
@@ -484,6 +553,7 @@ WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'0
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
+/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
 INNER JOIN
 (
   -- Begin Measurement Criteria
@@ -491,27 +561,31 @@ select C.person_id, C.measurement_id as event_id, C.measurement_date as start_da
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
+In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
-
+/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
+  ) 
+  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
+  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
+/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -519,6 +593,9 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 
 UNION ALL
 -- Begin Correlated Criteria
+
+/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
+/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
 SELECT 1 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
 FROM (-- Begin Observation Criteria
@@ -538,7 +615,10 @@ WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')|
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
-INNER JOIN
+INNER 
+/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -546,18 +626,20 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This pulling the concept set for Strong Positive Before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) C
-
+/**Restricting to after 01-01-2020 and before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -603,18 +685,20 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we specifiy the logic to look for a lab-confirmed negative.*/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
 
@@ -622,7 +706,7 @@ WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
-
+/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
@@ -636,6 +720,8 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
 UNION ALL
+/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
+/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
 -- Begin Correlated Criteria
 SELECT 2 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -649,7 +735,7 @@ from
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**Restricting to after 04-01-2020**/
 WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 -- End Observation Criteria
 ) Q
@@ -657,21 +743,29 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**Looking in the Measurement table for lab-confirmed positive**/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**Looking for the LOINC/HCPCS that are COVID**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
+/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
+This is where the logic from MS SQL Line 159-163 should have gone.**/
+WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+OR
+C.value_source_value in ('Positive', 'Present', 'Detected')
+	)
 
-WHERE C.value_as_concept_id in (4126681,45877985,45884084,9191)
+
 -- End Measurement Criteria
-
+/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -691,7 +785,7 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 WHERE P.ordinal = 1
 -- End Primary Events
 
-)
+) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
  SELECT
 event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 
@@ -705,6 +799,8 @@ FROM
 ;
 ANALYZE qualified_events
 ;
+
+/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
 
 --- Inclusion Rule Inserts
 
@@ -738,7 +834,7 @@ ANALYZE included_events
 ;
 
 
-
+/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
 -- generate cohort periods into #final_cohort
 CREATE TEMP TABLE cohort_rows
 
@@ -766,7 +862,8 @@ first_ends;
 ANALYZE cohort_rows
 ;
 
-with cteEndDates (person_id, end_date) AS -- the magic
+/**More Atlas generated code that largely goes unused.**/
+with cteEndDates (person_id, end_date) AS 
 (	
 	SELECT
 		person_id
@@ -818,6 +915,7 @@ from cteEnds
 group by person_id, end_date
 )
 
+/**The final collapsing of ALL the logic into the cohort table.**/
 --# BEGIN N3C_COHORT table to be retained
 
 --SELECT person_id
@@ -832,6 +930,7 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None' LIMIT 1) AS VOCABULARY_VERSION;
 
+/**Dropping out all the temp tables.**/
 
 TRUNCATE TABLE cohort_rows;
 DROP TABLE cohort_rows;

--- a/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
@@ -16,9 +16,9 @@ Script changes between 10-29 & 11-05: simplified script to human-written SQL (ve
 HOW TO RUN:
 You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-USER NOTES: 
-In OHDSI conventions, we do not usually write tables to the main database schema. 
-OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+USER NOTES:
+In OHDSI conventions, we do not usually write tables to the main database schema.
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis.
 We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
 To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
@@ -49,10 +49,6 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 
 
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
-SELECT DISTINCT person_id
-FROM
-(
-
 -- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
@@ -100,9 +96,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -182,9 +178,9 @@ WHERE condition_concept_id IN (
 				756081,
 				37310285
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -207,7 +203,7 @@ WHERE condition_concept_id IN (
 				)
 			AND c.invalid_reason IS NULL
 		)
-	
+
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 
 UNION
@@ -318,7 +314,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -413,7 +409,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -564,7 +560,7 @@ FROM (
 UNION
 
 -- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
--- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020,
 -- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
 
 -- We begin by looking for ANY COVID measurement
@@ -614,9 +610,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -635,10 +631,7 @@ WHERE measurement_concept_id IN (
 		WHERE observation_source_concept_id = 45595484
 			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 		)
-		
-		
-) 
-;
+		;
 
 
 

--- a/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
@@ -1,5 +1,5 @@
 /**
-Change log:
+CHANGE LOG:
 V1.1 - initial commit
 V1.2 - updated possible positive cases (typo in name of concept set name) and added additional NIH VSAC codeset_id
 V1.3 - consolidated to single cohort definition and added N3C COHORT table + labeling statements
@@ -11,17 +11,18 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
-incremental change on 10-29: simplified script
+Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
-To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+HOW TO RUN:
+You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-Harmonization note:
-In OHDSI conventions, we do not usually write tables to the main database schema.
-NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+USER NOTES: 
+In OHDSI conventions, we do not usually write tables to the main database schema. 
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
-
-Begin building cohort following OHDSI standard cohort definition process
-
+SCRIPT RELEASE DATE: 11-05-2020
 
 **/
 
@@ -39,6 +40,7 @@ CREATE TABLE @resultsDatabaseSchema.n3c_cohort (
 DROP TABLE IF EXISTS @resultsDatabaseSchema.phenotype_execution;
 
 -- Create dest table
+-- Here we need to know when you ran the phenotype, what version you're using and what vocabulary version you've built your OMOP concepts on
 CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 	run_datetime TIMESTAMP NOT NULL,
 	phenotype_version varchar(50) NOT NULL,
@@ -51,24 +53,13 @@ SELECT DISTINCT person_id
 FROM
 (
 
-/**
-
-INCLUSION:
-
-1) Postive COVID Measurement
-2) Strong positive dx
-3) 2x Weak Dx
-4) COVID Measurement & No occurrences of Z11.59 
-
-
-**/
-
--- 1) Positive COVID Measurement
+-- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -115,17 +106,26 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
+	-- Here we add a date restriction: after January 1, 2020
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 	AND (
+	-- The value_as_concept field is where we store standardized qualitative results
+	-- The concept ids here represent LOINC or SNOMED codes for standard ways to code a lab that is positive
 		value_as_concept_id IN (
-			4126681,
-			45877985,
-			45884084,
-			9191
+			45878583
+			,37079494
+			,1177295
+			,36307756
+			,36309158
+			,36308436
+			,9189
 			)
+	-- To be exhaustive, we also look for Positive strings in the value_source_value field
 		OR value_source_value IN (
 			'Positive'
 			,'Present'
@@ -135,88 +135,52 @@ WHERE measurement_concept_id IN (
 
 UNION
 
--- 2) Strong positive 
--- prior to 04-01
+-- Phenotype Entry Criteria: ONE or more of the â€œStrong Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables
+-- This section constructs entry logic prior to the CDC guidance issued on April 1, 2020
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				260125
-				,260139
-				,46271075
-				,4307774
-				,4195694
-				,257011
-				,442555
-				,4059022
-				,4059021
-				,256451
-				,4059003
-				,4168213
-				,434490
-				,439676
-				,254761
-				,4048098
-				,37311061
-				,4100065
-				,320136
-				,4038519
-				,312437
-				,4060052
-				,4263848
-				,37311059
-				,37016200
-				,4011766
-				,437663
-				,4141062
-				,4164645
-				,4047610
-				,4260205
-				,4185711
-				,4289517
-				,4140453
-				,4090569
-				,4109381
-				,4330445
-				,255848
-				,4102774
-				,436235
-				,261326
-				,320651
-				)
+			756023,
+			756044,
+			756061,
+			756031,
+			37311061,
+			756081,
+			37310285,
+			756039,
+			320651,
+			37311060
+			)
 		)
+	-- This logic imposes the restriction: these codes were only valid as Strong Positive codes between January 1, 2020 and March 31, 2020
 	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 		AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
 
 UNION
 
--- after 04-01
+-- The CDC issued guidance on April 1, 2020 that changed COVID coding conventions
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				37311061,
+				37311060,
+				756023,
+				756031,
+				756039,
+				756044,
+				756061,
+				756081,
+				37310285
 				)
 		
 		UNION
@@ -224,90 +188,119 @@ WHERE condition_concept_id IN (
 		SELECT c.concept_id
 		FROM @vocabulary_database_schema.CONCEPT c
 		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				756044,
+				37310285,
+				37310283,
+				756061,
+				756081,
+				37310287,
+				756023,
+				756031,
+				37310286,
+				37311061,
+				37310284,
+				756039,
+				37311060,
+				37310254
 				)
 			AND c.invalid_reason IS NULL
 		)
+	
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 
 UNION
 
--- 3) 2x Weak diagnosis 
--- prior to 04-01
--- same visit 
+-- 3) TWO or more of the â€œWeak Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables (below) during the same encounter or on the same date
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same date
+-- BEFORE 04-01-2020 "WEAK POSITIVE" LOGIC:
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
 	GROUP BY person_id
 		,visit_occurrence_id
 	HAVING count(*) >= 2
@@ -315,60 +308,90 @@ FROM (
 
 UNION
 
--- same date
+-- Now we apply logic to look for same visit AND same date
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,condition_start_date
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
 	GROUP BY person_id
@@ -378,17 +401,113 @@ FROM (
 
 UNION
 
--- after 04-01
--- same visit 
+-- AFTER 04-01-2020 "WEAK POSITIVE" LOGIC:
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same visit
+
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
+			WHERE concept_id IN (
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971,
+					320651
+					)
+			)
+	-- This code list is only valid for CDC guidance before 04-01-2020
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- Now we apply logic to look for same visit AND same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those term
 			WHERE concept_id IN (
 					260125
 					,260139
@@ -434,84 +553,27 @@ FROM (
 					,320651
 					)
 			)
+		-- This code list is based on CDC Guidance for code use AFTER 04-01-2020
 		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-	GROUP BY person_id
-		,visit_occurrence_id
-	HAVING count(*) >= 2
-	) dx_same_encounter
-
-UNION
-
--- same date
-SELECT DISTINCT person_id
-FROM (
-	SELECT person_id
-		,condition_start_date
-		,count(*)
-	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-	WHERE condition_concept_id IN (
-			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
-			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
-					,320651
-					)
-			)
-		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-	GROUP BY person_id
+-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
 		,condition_start_date
 	HAVING count(*) >= 2
 	) dx_same_date
 
 UNION
 
--- 4) COVID Measurement & No occurrences of Z11.59 
--- COVID lab test of any result
+-- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
+
+-- We begin by looking for ANY COVID measurement
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -558,11 +620,15 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
 	-- existence of Z11.59
+	-- Z11.59 here is being pulled from the source_concept_id
+	-- we want to make extra sure that we're ONLY looking at Z11.59 not the more general SNOMED code that would be in the standard concept id column for this
 	AND person_id NOT IN (
 		SELECT person_id
 		FROM @cdmDatabaseSchema.OBSERVATION
@@ -581,4 +647,3 @@ SELECT
     CURRENT_DATE as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None' LIMIT 1) AS VOCABULARY_VERSION;
-

--- a/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
@@ -14,7 +14,7 @@ V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes a
 Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
 HOW TO RUN:
-You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
+You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
 USER NOTES: 
 In OHDSI conventions, we do not usually write tables to the main database schema. 
@@ -141,7 +141,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -168,7 +168,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -186,8 +186,8 @@ WHERE condition_concept_id IN (
 		UNION
 		
 		SELECT c.concept_id
-		FROM @vocabulary_database_schema.CONCEPT c
-		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
 		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
 				756044,
@@ -221,7 +221,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -315,7 +315,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -410,7 +410,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -504,7 +504,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those term

--- a/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_postgres.sql
@@ -11,6 +11,7 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
+incremental change on 10-29: simplified script
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
 
@@ -25,6 +26,7 @@ Begin building cohort following OHDSI standard cohort definition process
 **/
 
 /** Creating the N3C Cohort table **/
+
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -44,885 +46,535 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution (
 );
 
 
--- OHDSI ATLAS generated cohort logic
-/** This block of code generates concept sets to be used in this phenotype**/
-CREATE TEMP TABLE Codesets  (codeset_id int NOT NULL,
-  concept_id bigint NOT NULL
-)
-;
-
-/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
-In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
-INSERT INTO Codesets (codeset_id, concept_id)
-SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756055)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO Codesets (codeset_id, concept_id)
-SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
-
-) I
-) C;
-INSERT INTO Codesets (codeset_id, concept_id)
-/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO Codesets (codeset_id, concept_id)
-/
-SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-INSERT INTO Codesets (codeset_id, concept_id)
-SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
-
-) I
-) C;
-/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
-The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
-You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
-INSERT INTO Codesets (codeset_id, concept_id)
-SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (45595484)
-
-) I
-) C;
-
-/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
-It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
-In the case of N3C, we don't impart any rules here.**/
-CREATE TEMP TABLE qualified_events
-
-AS
-WITH primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id)  AS (
--- Begin Primary Events
-select P.ordinal as event_id, P.person_id, P.start_date, P.end_date, op_start_date, op_end_date, cast(P.visit_occurrence_id as bigint) as visit_occurrence_id
-FROM
-(
-  select E.person_id, E.start_date, E.end_date,
-         row_number() OVER (PARTITION BY E.person_id ORDER BY E.sort_date ASC) ordinal,
-         OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM 
-  (
-/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
-The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-
-WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
-/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
- AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
- OR
- C.value_source_value in ('Positive', 'Present', 'Detected')
- ) **/
- -- End Measurement Criteria
-
-UNION ALL
-/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
-
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**The next code is saying to look for a strong positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-UNION ALL
-
-/**The next code is saying to look for a strong positive on or after 04-01-2020**/
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
-UNION ALL
-/**The next code is saying to look for a Weak Positive before 04-01-2020**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
-It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
-AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
-It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
-JOIN (
--- Begin Criteria Group
-select 0 as index_id, person_id, event_id
-FROM
-/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/* This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/** This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + 0*INTERVAL'1 day') AND A.START_DATE <= (P.START_DATE + 0*INTERVAL'1 day')
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
-
-UNION ALL
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**OCCURRENCE 1**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(05,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**OCCURRENCE 2**/
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= (P.START_DATE + 0*INTERVAL'1 day') AND A.START_DATE <= (P.START_DATE + 0*INTERVAL'1 day')
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
-
-UNION ALL
-/**We have to now apply logic to look for Asymptomatic patients.
-This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
-Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
-It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
-So we start by building a piece of logic to look at the OBSERVATION domain.**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**Here's where things get interesting... we want to restrict Z11.59 to be with:
-At least 1 Strong Positive On or After 04-01-2020
- --> but not people who have a lab-confirmed negative
-OR
-At least 1 Strong Positive Before 04-01-2020
- --> but not people who have a lab-confirmed negative
- OR
-At least 1 Lab-confirmed Positive **/
-
-/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**This is where we impart the date rule: on or after 04-01-2020**/
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**We add the date criteria: on or after 04-01-2020**/
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-) Q
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
-INNER JOIN
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
-In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) 
-  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
-  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
--- Begin Correlated Criteria
-
-/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
-/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
-SELECT 1 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER 
-/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This pulling the concept set for Strong Positive Before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-/**Restricting to after 01-01-2020 and before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, (C.condition_start_date + 1*INTERVAL'1 day')) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we specifiy the logic to look for a lab-confirmed negative.*/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
-/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
-/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
--- Begin Correlated Criteria
-SELECT 2 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, (C.observation_date + 1*INTERVAL'1 day') as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**Restricting to after 04-01-2020**/
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**Looking in the Measurement table for lab-confirmed positive**/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, (C.measurement_date + 1*INTERVAL'1 day') as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**Looking for the LOINC/HCPCS that are COVID**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
-This is where the logic from MS SQL Line 159-163 should have gone.**/
-WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-OR
-C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
-
-
--- End Measurement Criteria
-/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) >= 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-  ) E
-	JOIN @cdmDatabaseSchema.observation_period OP on E.person_id = OP.person_id and E.start_date >=  OP.observation_period_start_date and E.start_date <= op.observation_period_end_date
-  WHERE (OP.OBSERVATION_PERIOD_START_DATE + 0*INTERVAL'1 day') <= E.START_DATE AND (E.START_DATE + 0*INTERVAL'1 day') <= OP.OBSERVATION_PERIOD_END_DATE
-) P
-WHERE P.ordinal = 1
--- End Primary Events
-
-) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
- SELECT
-event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
-
-FROM
-(
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date ASC) as ordinal, cast(pe.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM primary_events pe
-  
-) QE
-
-;
-ANALYZE qualified_events
-;
-
-/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
-
---- Inclusion Rule Inserts
-
-CREATE TEMP TABLE inclusion_events  (inclusion_rule_id bigint,
-	person_id bigint,
-	event_id bigint
-);
-
-CREATE TEMP TABLE included_events
-
-AS
-WITH cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal)  AS (
-  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, row_number() over (partition by person_id order by start_date ASC) as ordinal
-  from
-  (
-    select Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as bigint), I.inclusion_rule_id), 0)) as inclusion_rule_mask
-    from qualified_events Q
-    LEFT JOIN inclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
-    GROUP BY Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date
-  ) MG -- matching groups
-
-)
- SELECT
-event_id, person_id, start_date, end_date, op_start_date, op_end_date
-
-FROM
-cteIncludedEvents Results
-WHERE Results.ordinal = 1
-;
-ANALYZE included_events
-;
-
-
-/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
--- generate cohort periods into #final_cohort
-CREATE TEMP TABLE cohort_rows
-
-AS
-WITH cohort_ends (event_id, person_id, end_date)  AS (
-	-- cohort exit dates
-  -- By default, cohort exit at the event's op end date
-select event_id, person_id, op_end_date as end_date from included_events
-),
-first_ends (person_id, start_date, end_date) as
-(
-	select F.person_id, F.start_date, F.end_date
-	FROM (
-	  select I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
-	  from included_events I
-	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
-	) F
-	WHERE F.ordinal = 1
-)
- SELECT
-person_id, start_date, end_date
-
-FROM
-first_ends;
-ANALYZE cohort_rows
-;
-
-/**More Atlas generated code that largely goes unused.**/
-with cteEndDates (person_id, end_date) AS 
-(	
-	SELECT
-		person_id
-		, (event_date + -1 * 0*INTERVAL'1 day')  as end_date
-	FROM
-	(
-		SELECT
-			person_id
-			, event_date
-			, event_type
-			, MAX(start_ordinal) OVER (PARTITION BY person_id ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal 
-			, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY event_date, event_type) AS overall_ord
-		FROM
-		(
-			SELECT
-				person_id
-				, start_date AS event_date
-				, -1 AS event_type
-				, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date) AS start_ordinal
-			FROM cohort_rows
-		
-			UNION ALL
-		
-
-			SELECT
-				person_id
-				, (end_date + 0*INTERVAL'1 day') as end_date
-				, 1 AS event_type
-				, NULL
-			FROM cohort_rows
-		) RAWDATA
-	) e
-	WHERE (2 * e.start_ordinal) - e.overall_ord = 0
-),
-cteEnds (person_id, start_date, end_date) AS
-(
-	SELECT
-		 c.person_id
-		, c.start_date
-		, MIN(e.end_date) AS end_date
-	FROM cohort_rows c
-	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
-	GROUP BY c.person_id, c.start_date
-),
-final_cohort (person_id, start_date, end_date) AS
-(
-select person_id, min(start_date) as start_date, end_date
-from cteEnds
-group by person_id, end_date
-)
-
-/**The final collapsing of ALL the logic into the cohort table.**/
---# BEGIN N3C_COHORT table to be retained
-
---SELECT person_id
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
-SELECT DISTINCT
-    person_id
-FROM final_cohort;
+SELECT DISTINCT person_id
+FROM
+(
+
+/**
+
+INCLUSION:
+
+1) Postive COVID Measurement
+2) Strong positive dx
+3) 2x Weak Dx
+4) COVID Measurement & No occurrences of Z11.59 
+
+
+**/
+
+-- 1) Positive COVID Measurement
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	AND (
+		value_as_concept_id IN (
+			4126681,
+			45877985,
+			45884084,
+			9191
+			)
+		OR value_source_value IN (
+			'Positive'
+			,'Present'
+			,'Detected'
+			)
+		)
+
+UNION
+
+-- 2) Strong positive 
+-- prior to 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				260125
+				,260139
+				,46271075
+				,4307774
+				,4195694
+				,257011
+				,442555
+				,4059022
+				,4059021
+				,256451
+				,4059003
+				,4168213
+				,434490
+				,439676
+				,254761
+				,4048098
+				,37311061
+				,4100065
+				,320136
+				,4038519
+				,312437
+				,4060052
+				,4263848
+				,37311059
+				,37016200
+				,4011766
+				,437663
+				,4141062
+				,4164645
+				,4047610
+				,4260205
+				,4185711
+				,4289517
+				,4140453
+				,4090569
+				,4109381
+				,4330445
+				,255848
+				,4102774
+				,436235
+				,261326
+				,320651
+				)
+		)
+	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+		AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+
+UNION
+
+-- after 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @vocabulary_database_schema.CONCEPT c
+		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+			AND c.invalid_reason IS NULL
+		)
+	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+
+UNION
+
+-- 3) 2x Weak diagnosis 
+-- prior to 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(03,'00')||'-'||TO_CHAR(31,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- after 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- 4) COVID Measurement & No occurrences of Z11.59 
+-- COVID lab test of any result
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+	-- existence of Z11.59
+	AND person_id NOT IN (
+		SELECT person_id
+		FROM @cdmDatabaseSchema.OBSERVATION
+		WHERE observation_source_concept_id = 45595484
+			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000')||'-'||TO_CHAR(04,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD')
+		)
+		
+		
+) 
+;
+
+
 
 INSERT INTO @resultsDatabaseSchema.phenotype_execution
 SELECT
@@ -930,19 +582,3 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT  vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None' LIMIT 1) AS VOCABULARY_VERSION;
 
-/**Dropping out all the temp tables.**/
-
-TRUNCATE TABLE cohort_rows;
-DROP TABLE cohort_rows;
-
-TRUNCATE TABLE inclusion_events;
-DROP TABLE inclusion_events;
-
-TRUNCATE TABLE qualified_events;
-DROP TABLE qualified_events;
-
-TRUNCATE TABLE included_events;
-DROP TABLE included_events;
-
-TRUNCATE TABLE Codesets;
-DROP TABLE Codesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -16,9 +16,9 @@ Script changes between 10-29 & 11-05: simplified script to human-written SQL (ve
 HOW TO RUN:
 You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-USER NOTES: 
-In OHDSI conventions, we do not usually write tables to the main database schema. 
-OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+USER NOTES:
+In OHDSI conventions, we do not usually write tables to the main database schema.
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis.
 We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
 To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
@@ -49,10 +49,6 @@ DISTSTYLE ALL;
 
 
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
-SELECT DISTINCT person_id
-FROM
-(
-
 -- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
@@ -100,9 +96,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -182,9 +178,9 @@ WHERE condition_concept_id IN (
 				756081,
 				37310285
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -207,7 +203,7 @@ WHERE condition_concept_id IN (
 				)
 			AND c.invalid_reason IS NULL
 		)
-	
+
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 
 UNION
@@ -318,7 +314,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -413,7 +409,7 @@ FROM (
 			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
-		-- This is the list of standard concepts that represent those terms	
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
 					260125,
 					260139,
@@ -564,7 +560,7 @@ FROM (
 UNION
 
 -- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
--- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020,
 -- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
 
 -- We begin by looking for ANY COVID measurement
@@ -614,9 +610,9 @@ WHERE measurement_concept_id IN (
 				,757686
 				,756055
 				)
-		
+
 		UNION
-		
+
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
@@ -635,10 +631,7 @@ WHERE measurement_concept_id IN (
 		WHERE observation_source_concept_id = 45595484
 			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 		)
-		
-		
-) 
-;
+		;
 
 
 

--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -10,17 +10,10 @@ V2.0 - dropping weak diagnosis after May 1, adding asymptomatic test code (Z11.5
 changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
-
-Instructions:
-Cohorts were assembled using OHDSI Atlas (atlas-covid19.ohdsi.org)
-This MS SQL script is the artifact of this ATLAS cohort definition: http://atlas-covid19.ohdsi.org/#/cohortdefinition/1119
-If desired to evaluate feasibility of each cohort, individual cohorts are available:
-1- Lab-confirmed positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/655)
-2- Lab-confirmed negative cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/656)
-3- Suspected positive cases	(http://atlas-covid19.ohdsi.org/#/cohortdefinition/657)
-4- Possible positive cases (http://atlas-covid19.ohdsi.org/#/cohortdefinition/658)
+V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+
 Harmonization note:
 In OHDSI conventions, we do not usually write tables to the main database schema.
 NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
@@ -31,6 +24,7 @@ Begin building cohort following OHDSI standard cohort definition process
 
 **/
 
+/** Creating the N3C Cohort table **/
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -49,12 +43,16 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution  (run_datetime TIMESTAMP
 )
 DISTSTYLE ALL;
 
+
 -- OHDSI ATLAS generated cohort logic
+/** This block of code generates concept sets to be used in this phenotype**/
 CREATE TABLE #Codesets  (codeset_id int NOT NULL,
   concept_id bigint NOT NULL
 )
 DISTSTYLE ALL;
 
+/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
+In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -67,6 +65,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -75,6 +76,9 @@ SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 INSERT INTO #Codesets (codeset_id, concept_id)
+/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
@@ -86,7 +90,11 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
+/
 SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
   select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
@@ -98,6 +106,9 @@ UNION  select c.concept_id
 
 ) I
 ) C;
+/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
+In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
+We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -105,6 +116,9 @@ SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 
 ) I
 ) C;
+/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
+The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
+You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
 INSERT INTO #Codesets (codeset_id, concept_id)
 SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ( 
@@ -113,7 +127,9 @@ SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
 ) I
 ) C;
 
-
+/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
+It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
+In the case of N3C, we don't impart any rules here.**/
 CREATE TABLE #qualified_events
 
 DISTKEY(person_id)
@@ -131,6 +147,8 @@ FROM
          OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
   FROM 
   (
+/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
+The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -143,18 +161,22 @@ JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and 
 ) C
 
 WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
-AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-	OR
-	C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
--- End Measurement Criteria
+/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
+ AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+ OR
+ C.value_source_value in ('Positive', 'Present', 'Detected')
+ ) **/
+ -- End Measurement Criteria
 
 UNION ALL
+/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
+
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**The next code is saying to look for a strong positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -165,6 +187,8 @@ WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01
 -- End Condition Occurrence Criteria
 
 UNION ALL
+
+/**The next code is saying to look for a strong positive on or after 04-01-2020**/
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
@@ -180,6 +204,7 @@ WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,
 -- End Condition Occurrence Criteria
 
 UNION ALL
+/**The next code is saying to look for a Weak Positive before 04-01-2020**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
@@ -196,10 +221,15 @@ WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01
 -- End Condition Occurrence Criteria
 
 ) PE
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
+It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
+AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
+It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
 JOIN (
 -- Begin Criteria Group
 select 0 as index_id, person_id, event_id
 FROM
+/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
 (
   select E.person_id, E.event_id 
   FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -208,12 +238,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/* This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -230,12 +261,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
 ) C
-
+/** This code tells it what dates: before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -249,6 +281,7 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -257,38 +290,44 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,CAST(0 as int),P.START_DATE) AND A.START_DATE <= DATEADD(day,CAST(0 as int),P.START_DATE)
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
 
 UNION ALL
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
+/**OCCURRENCE 1**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -299,12 +338,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -321,12 +361,13 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
 ) C
-
+/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 ) Q
@@ -334,12 +375,14 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**OCCURRENCE 2**/
 (
   -- Begin Condition Occurrence Criteria
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
@@ -348,38 +391,55 @@ FROM
 
 
 -- End Condition Occurrence Criteria
-
+/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,CAST(0 as int),P.START_DATE) AND A.START_DATE <= DATEADD(day,CAST(0 as int),P.START_DATE)
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
 -- End Correlated Criteria
-
+/**The next code is making sure you have it on the same day**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) = 1
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
+/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
 
 UNION ALL
+/**We have to now apply logic to look for Asymptomatic patients.
+This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
+Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
+It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
+So we start by building a piece of logic to look at the OBSERVATION domain.**/
 select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Observation Criteria
 select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
        C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.observation_date as sort_date
 from 
+/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
 (
   select o.* 
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
 WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 -- End Observation Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/**Here's where things get interesting... we want to restrict Z11.59 to be with:
+At least 1 Strong Positive On or After 04-01-2020
+ --> but not people who have a lab-confirmed negative
+OR
+At least 1 Strong Positive Before 04-01-2020
+ --> but not people who have a lab-confirmed negative
+ OR
+At least 1 Lab-confirmed Positive **/
+
+/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -425,6 +485,7 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -432,18 +493,22 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**This is where we impart the date rule: on or after 04-01-2020**/
 WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -454,15 +519,19 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
 ) C
-
+/**We add the date criteria: on or after 04-01-2020**/
 WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 -- End Condition Occurrence Criteria
 ) Q
+/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) E
@@ -488,6 +557,7 @@ WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
+/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
 INNER JOIN
 (
   -- Begin Measurement Criteria
@@ -495,27 +565,31 @@ select C.person_id, C.measurement_id as event_id, C.measurement_date as start_da
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
+In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
-
+/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
+  ) 
+  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
+  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
 ) G
 -- End Criteria Group
 ) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
+/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -523,6 +597,9 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 
 UNION ALL
 -- Begin Correlated Criteria
+
+/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
+/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
 SELECT 1 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
 FROM (-- Begin Observation Criteria
@@ -542,7 +619,10 @@ WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00F
 JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
-INNER JOIN
+INNER 
+/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
+We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
+We start by respecify the CONDITION_OCCURRENCE criteria.**/
 (
   select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
 -- Begin Condition Occurrence Criteria
@@ -550,18 +630,20 @@ SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_dat
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
+/** This pulling the concept set for Strong Positive Before 04-01-2020**/
 (
   SELECT co.* 
   FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
   JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
 ) C
-
+/**Restricting to after 01-01-2020 and before 04-01-2020**/
 WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
 -- End Condition Occurrence Criteria
 
 ) PE
 JOIN (
 -- Begin Criteria Group
+/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
 select 0 as index_id, person_id, event_id
 FROM
 (
@@ -607,18 +689,20 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/*Now we specifiy the logic to look for a lab-confirmed negative.*/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
-
+/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
 WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
 -- End Measurement Criteria
 
@@ -626,7 +710,7 @@ WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,3630
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
-
+/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
   HAVING COUNT(index_id) <= 0
@@ -640,6 +724,8 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 -- End Correlated Criteria
 
 UNION ALL
+/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
+/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
 -- Begin Correlated Criteria
 SELECT 2 as index_id, p.person_id, p.event_id
 FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
@@ -653,7 +739,7 @@ from
   FROM @cdmDatabaseSchema.OBSERVATION o
 JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
 ) C
-
+/**Restricting to after 04-01-2020**/
 WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 -- End Observation Criteria
 ) Q
@@ -661,21 +747,29 @@ JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id
   and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
 ) P
 INNER JOIN
+/**Looking in the Measurement table for lab-confirmed positive**/
 (
   -- Begin Measurement Criteria
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
        C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.measurement_date as sort_date
 from 
+/**Looking for the LOINC/HCPCS that are COVID**/
 (
   select m.* 
   FROM @cdmDatabaseSchema.MEASUREMENT m
 JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
 ) C
+/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
+This is where the logic from MS SQL Line 159-163 should have gone.**/
+WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
+OR
+C.value_source_value in ('Positive', 'Present', 'Detected')
+	)
 
-WHERE C.value_as_concept_id in (4126681,45877985,45884084,9191)
+
 -- End Measurement Criteria
-
+/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
 ) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
 GROUP BY p.person_id, p.event_id
 HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
@@ -695,7 +789,7 @@ HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
 WHERE P.ordinal = 1
 -- End Primary Events
 
-)
+) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
 
 SELECT
 event_id,  person_id , start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
@@ -708,6 +802,8 @@ FROM
 ) QE
 
 ;
+
+/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
 
 --- Inclusion Rule Inserts
 
@@ -745,7 +841,7 @@ WHERE Results.ordinal = 1
 ;
 
 
-
+/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
 -- generate cohort periods into #final_cohort
 CREATE TABLE #cohort_rows
 
@@ -776,8 +872,9 @@ SELECT
 FROM
 first_ends;
 
+/**More Atlas generated code that largely goes unused.**/
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
- WITH cteEndDates (person_id, end_date) AS -- the magic
+ WITH cteEndDates (person_id, end_date) AS 
 (	
 	SELECT
 		person_id
@@ -829,6 +926,7 @@ from cteEnds
 group by person_id, end_date
 )
 
+/**The final collapsing of ALL the logic into the cohort table.**/
 --# BEGIN N3C_COHORT table to be retained
 
 --SELECT person_id
@@ -842,6 +940,7 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
 
+/**Dropping out all the temp tables.**/
 
 TRUNCATE TABLE #cohort_rows;
 DROP TABLE #cohort_rows;

--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -14,7 +14,7 @@ V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes a
 Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
 HOW TO RUN:
-You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
+You will need to find and replace @cdmDatabaseSchema and @resultsDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
 USER NOTES: 
 In OHDSI conventions, we do not usually write tables to the main database schema. 
@@ -141,7 +141,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -168,7 +168,7 @@ SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
-		FROM @vocabulary_database_schema.CONCEPT
+		FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
@@ -186,8 +186,8 @@ WHERE condition_concept_id IN (
 		UNION
 		
 		SELECT c.concept_id
-		FROM @vocabulary_database_schema.CONCEPT c
-		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
 		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
 				756044,
@@ -221,7 +221,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms
@@ -315,7 +315,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -410,7 +410,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those terms	
@@ -504,7 +504,7 @@ FROM (
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
+			FROM @cdmDatabaseSchema.CONCEPT
 		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
 		-- It also includes the OMOP only codes that are on the Phenotype Wiki
 		-- This is the list of standard concepts that represent those term

--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -11,6 +11,7 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
+incremental change on 10-29: simplified script
 
 To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
 
@@ -25,6 +26,7 @@ Begin building cohort following OHDSI standard cohort definition process
 **/
 
 /** Creating the N3C Cohort table **/
+
 --DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort; -- RUN THIS LINE AFTER FIRST BUILD
 DROP TABLE IF EXISTS @resultsDatabaseSchema.n3c_cohort;
 
@@ -44,895 +46,535 @@ CREATE TABLE @resultsDatabaseSchema.phenotype_execution  (run_datetime TIMESTAMP
 DISTSTYLE ALL;
 
 
--- OHDSI ATLAS generated cohort logic
-/** This block of code generates concept sets to be used in this phenotype**/
-CREATE TABLE #Codesets  (codeset_id int NOT NULL,
-  concept_id bigint NOT NULL
-)
-DISTSTYLE ALL;
-
-/**This code creates the [CD2H Lab Concepts] concept set - which pulls LOINC codes for inclusion.
-In phenotype 2.2 - we readded 756055 per the request of a site using this OMOP extension code.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 0 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (586515,586522,706179,586521,723459,706181,706177,706176,706180,706178,706167,706157,706155,757678,706161,586520,706175,706156,706154,706168,715262,586526,757677,706163,715260,715261,706170,706158,706169,706160,706173,586519,586516,757680,757679,586517,757686,756055)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756055)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive After to 04-01-2020] concept set- which pulls the updated list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 2 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326,320651)
-
-) I
-) C;
-INSERT INTO #Codesets (codeset_id, concept_id)
-/**This code creates the [CD2H Strong Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-SELECT 3 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,320651,4100065)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Strong Positive After 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have removed the descendant concepts from this after concept set because the coding stringency has changed.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-/
-SELECT 4 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-UNION  select c.concept_id
-  from @cdmDatabaseSchema.CONCEPT c
-  join @cdmDatabaseSchema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
-  and ca.ancestor_concept_id in (756023,756044,756061,756031,37311061,756081,37310285,756039,37311060,756023,756044,756061,756031,37311061,756081,37310285,756039,37311060)
-  and c.invalid_reason is null
-
-) I
-) C;
-/**This code creates the [CD2H Weak Positive Prior to 04-01-2020] concept set-which pulls the prior list of SNOMED codes that ICD10 codes map to.
-In the phenotype, we have 04-01-2020 as a cut point related to changes in CDC coding guidance.
-We have left the descendant concepts in the earlier concept set because there was less specificity in coding at that point in time. **/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 5 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (260125,260139,46271075,4307774,4195694,257011,442555,4059022,4059021,256451,4059003,4168213,434490,439676,254761,4048098,37311061,4100065,320136,4038519,312437,4060052,4263848,37311059,37016200,4011766,437663,4141062,4164645,4047610,4260205,4185711,4289517,4140453,4090569,4109381,4330445,255848,4102774,436235,261326)
-
-) I
-) C;
-/**This code creates the [CD2H Asymptomatic] concept set. This is an unusual concept set because we're using a non-standard code. 
-The rationale here is that the standard concept that Z11.59 maps to is "too generic" than the source concept. In this case, we are allowing a non-standard code to be used.
-You will see logic in the use of this concept set to indicate to the CDM where to pull this from. If you do not do this, you run the risk of ATLAS not pulling from the right column as Standard concepts and Source concepts live in different columns in the domain.**/
-INSERT INTO #Codesets (codeset_id, concept_id)
-SELECT 6 as codeset_id, c.concept_id FROM (select distinct I.concept_id FROM
-( 
-  select concept_id from @cdmDatabaseSchema.CONCEPT where concept_id in (45595484)
-
-) I
-) C;
-
-/** This block of code is beginning to ascribe the "Index" event to how someone qualifies for the phenotype.
-It will begin to assemble a cohort based off of any rules related to observation_period (aka the time someone is continuously followed in the data).
-In the case of N3C, we don't impart any rules here.**/
-CREATE TABLE #qualified_events
-
-DISTKEY(person_id)
-AS
-WITH
-primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id) 
-AS
-(
--- Begin Primary Events
-select P.ordinal as event_id, P.person_id, P.start_date, P.end_date, op_start_date, op_end_date, cast(P.visit_occurrence_id as bigint) as visit_occurrence_id
-FROM
-(
-  select E.person_id, E.start_date, E.end_date,
-         ROW_NUMBER() OVER (PARTITION BY E.person_id  ORDER BY E.sort_date  ASC ) ordinal,
-         OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, cast(E.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM 
-  (
-/**This block of code begins a series of boolean statements (e.g. this OR that OR that). 
-The first being looking at the MEASUREMENT domain to see if someone has a lab [the list of which we specified in that concept set above] on or after the Jan 1, 2020**/
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-
-WHERE C.measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
-/** THIS LOGIC WAS INADVERTENTLY PLACED IN THE WRONG EVENT AREA IN V2.1/2.2. IT IS NOW COMMENTED OUT FOR TRANSPARENCY AND WILL BE REMOVED IN SIMPLIFICATION.
- AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
- OR
- C.value_source_value in ('Positive', 'Present', 'Detected')
- ) **/
- -- End Measurement Criteria
-
-UNION ALL
-/**Now, we're looking for people who meet eligibility if they meet one of the two CONDITION_OCCURRENCE criteria.**/
-
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**The next code is saying to look for a strong positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-UNION ALL
-
-/**The next code is saying to look for a strong positive on or after 04-01-2020**/
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
-UNION ALL
-/**The next code is saying to look for a Weak Positive before 04-01-2020**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020 on the same day.
-It looks really complicated because it's a nested thought: "Find me someone who has a CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020
-AND THEN look at that person's records and find me someone who has TWO DISTINCT CONDITION_OCCURRENCE of the allowable Weak Positive concepts before 04-01-2020 on the same day.
-It'll be coalescing dates to understand "what is the same day" and it will use the concept set (=5) multiple times to look up this list of allowable concepts.**/
-JOIN (
--- Begin Criteria Group
-select 0 as index_id, person_id, event_id
-FROM
-/* This code says look for that initial CONDITION_OCCURRENCE of a qualifying Weak Positive**/
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/* This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/* This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-/** This code tells it what dates: before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 5))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive before 04-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,CAST(0 as int),P.START_DATE) AND A.START_DATE <= DATEADD(day,CAST(0 as int),P.START_DATE)
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive before 04-01-2020. But we're not done, we have to apply similar logic for Weak Positive between 04-01-2020 and 05-01-2020**/
-
-UNION ALL
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**First we establish that someone has a condition occurrence of Weak Positive between 04-01-2020 and 05-01-2020**//
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**The next code is making sure you have TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-/**OCCURRENCE 1**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-/** This code tells it what dates: between 04-01-2020 and 05-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(05,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**OCCURRENCE 2**/
-(
-  -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This code tells it which concept set to pull: Weak Positive between 04-01-2020 and 05-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 2))
-) C
-
-
--- End Condition Occurrence Criteria
-/**The next code is making extra sure it's TWO distinct occurrences of the Weak Positive between 04-01-2020 and 05-01-2020**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= DATEADD(day,CAST(0 as int),P.START_DATE) AND A.START_DATE <= DATEADD(day,CAST(0 as int),P.START_DATE)
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(DISTINCT A.TARGET_CONCEPT_ID) >= 2
--- End Correlated Criteria
-/**The next code is making sure you have it on the same day**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) = 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**That's the end of the Weak Positive logic inclusive of through 05-01-2020**/
-
-UNION ALL
-/**We have to now apply logic to look for Asymptomatic patients.
-This one is going to get extra confusing because we're using a non-standard concept for Z11.59 so we have to do some extra gymnastics.
-Z11.59 is a condition code in ICD-10 vocabulary but in OMOP, you will find it in the OBSERVATION domain because the absence of a condition is not an active condition.
-It's an observation about the patient. Thus, it lives in the DOMAIN_ID = OBSERVATION.
-So we start by building a piece of logic to look at the OBSERVATION domain.**/
-select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-/** Now, we break devout OMOP rules. We ask the logic, "can you look for this in the source_concept_ids?" because the code is not a standard that's in the concept set.**/
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**And we say, well we want this on or after 04-01-2020, when the CDC guidance started.**/
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Observation Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/**Here's where things get interesting... we want to restrict Z11.59 to be with:
-At least 1 Strong Positive On or After 04-01-2020
- --> but not people who have a lab-confirmed negative
-OR
-At least 1 Strong Positive Before 04-01-2020
- --> but not people who have a lab-confirmed negative
- OR
-At least 1 Lab-confirmed Positive **/
-
-/**We state what we want: People with Z11.59 on or after 04-01-2020-- same exact logic as what you saw above**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  INNER JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we're going to specify logic to get to at least 1 Strong Positive On or After 04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**This is where we give the concept set: Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**This is where we impart the date rule: on or after 04-01-2020**/
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/**We make sure to link this to the concept set for Strong Positive On or After 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-/**We add the date criteria: on or after 04-01-2020**/
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-) Q
-/** Now we want to take the Strong Positive On or After 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 4))
-) C
-
-WHERE C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-/**We restrict the Strong Positive On or After 04-01-2020 cohort that's specified to now look for who has measurement data**/
-INNER JOIN
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**This statement below allows us to look up the allowable LOINC / HCPCS code for COVID labs**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**This statement below says: "If there is a lab, find me the ones who are NEGATIVE." 
-In OMOP, value_as_concept_id is the standard representation of the qualitative results.**/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-/**Counting people who have a Z11.59 + a lab-confirmed negative.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) 
-  /**Restricting to people who DO NOT have a lab-confirmed negative test.**/
-  CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-/**Keeping people who have a Z11.59 + a Strong Positive On or After 04-01-2020.**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
--- Begin Correlated Criteria
-
-/**Now we've got to move on in our logic... we want to find people who have a Z11.59 + a Strong Positive Before 04-01-2020.**/
-/**Here's the OBSERVATION logic again where we're looking for Z11.59 after 04-01-2020**/
-SELECT 1 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER 
-/** Now we want to take the Strong Positive Before 04-01-2020 cohort and filter it further.
-We're going to create a Criteria grouping here to look at the people who meet Strong Positive On or After 04-01-2020 and then filter out people who have negative results.
-We start by respecify the CONDITION_OCCURRENCE criteria.**/
-(
-  select PE.person_id, PE.event_id, PE.start_date, PE.end_date, PE.target_concept_id, PE.visit_occurrence_id, PE.sort_date FROM (
--- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-/** This pulling the concept set for Strong Positive Before 04-01-2020**/
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-/**Restricting to after 01-01-2020 and before 04-01-2020**/
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-
-) PE
-JOIN (
--- Begin Criteria Group
-/*Now we're going to respecify the logic to get to at least 1 Strong Positive Before  04-01-2020... and soon we will filter: but not people who have a lab-confirmed negative**/
-select 0 as index_id, person_id, event_id
-FROM
-(
-  select E.person_id, E.event_id 
-  FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) E
-  LEFT JOIN
-  (
-    -- Begin Correlated Criteria
-SELECT 0 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,CAST(1 as int),C.condition_start_date)) as end_date,
-       C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.condition_start_date as sort_date
-FROM 
-(
-  SELECT co.* 
-  FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE co
-  JOIN #Codesets codesets on ((co.condition_concept_id = codesets.concept_id and codesets.codeset_id = 3))
-) C
-
-WHERE (C.condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD') and C.condition_start_date <= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD'))
--- End Condition Occurrence Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/*Now we specifiy the logic to look for a lab-confirmed negative.*/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/*Pulling from the concept set of LOINC and HCPCS codes for COVID.*/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/*Looking specifically for people who are lab-confirmed negative using the value_as_concept_id field where we standardize qualitative results.*/
-WHERE C.value_as_concept_id in (45878583,37079494,1177295,36307756,36309158,36308436,9189)
--- End Measurement Criteria
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-/**Filtering to keep Z11.59 AND Strong Positive before 04-01-2020 but only those who are NOT lab-confirmed negative.**/
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) <= 0
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-UNION ALL
-/**One last OR criteria here... if we don't have you as Z11.59 with a Strong Positive... we want you if you're Z11.59 with a lab-confirmed positive.**/
-/**We begin this by stating the Z11.59 criteria from the beginning -- looking at the observation table for that specific code.**/
--- Begin Correlated Criteria
-SELECT 2 as index_id, p.person_id, p.event_id
-FROM (SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, Q.visit_occurrence_id, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
-FROM (-- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,CAST(1 as int),C.observation_date) as END_DATE,
-       C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.observation_date as sort_date
-from 
-(
-  select o.* 
-  FROM @cdmDatabaseSchema.OBSERVATION o
-JOIN #Codesets codesets on ((o.observation_source_concept_id = codesets.concept_id and codesets.codeset_id = 6))
-) C
-/**Restricting to after 04-01-2020**/
-WHERE C.observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
--- End Observation Criteria
-) Q
-JOIN @cdmDatabaseSchema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
-  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date
-) P
-INNER JOIN
-/**Looking in the Measurement table for lab-confirmed positive**/
-(
-  -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,CAST(1 as int),C.measurement_date) as END_DATE,
-       C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id,
-       C.measurement_date as sort_date
-from 
-/**Looking for the LOINC/HCPCS that are COVID**/
-(
-  select m.* 
-  FROM @cdmDatabaseSchema.MEASUREMENT m
-JOIN #Codesets codesets on ((m.measurement_concept_id = codesets.concept_id and codesets.codeset_id = 0))
-) C
-/**Specifying the value_as_concept_ids for positive and allowing a string search for where people have not coded these lab-confirmed qualitative results.\
-This is where the logic from MS SQL Line 159-163 should have gone.**/
-WHERE AND ( C.value_as_concept_id in (4126681,45877985,45884084,9191)
-OR
-C.value_source_value in ('Positive', 'Present', 'Detected')
-	)
-
-
--- End Measurement Criteria
-/**Now bringing this logic together to look for people who are Z11.59 and Lab-confirmed positive**/
-) A on A.person_id = P.person_id  AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE AND A.START_DATE >= P.OP_START_DATE AND A.START_DATE <= P.OP_END_DATE
-GROUP BY p.person_id, p.event_id
-HAVING COUNT(A.TARGET_CONCEPT_ID) >= 1
--- End Correlated Criteria
-
-  ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
-  GROUP BY E.person_id, E.event_id
-  HAVING COUNT(index_id) >= 1
-) G
--- End Criteria Group
-) AC on AC.person_id = pe.person_id and AC.event_id = pe.event_id
-
-  ) E
-	JOIN @cdmDatabaseSchema.observation_period OP on E.person_id = OP.person_id and E.start_date >=  OP.observation_period_start_date and E.start_date <= op.observation_period_end_date
-  WHERE DATEADD(day,CAST(0 as int),OP.OBSERVATION_PERIOD_START_DATE) <= E.START_DATE AND DATEADD(day,CAST(0 as int),E.START_DATE) <= OP.OBSERVATION_PERIOD_END_DATE
-) P
-WHERE P.ordinal = 1
--- End Primary Events
-
-) /*The following code is a vestigal part of Atlas-generated code. If we had additional qualifying logic that restricted cohort entry, we'd see it here. But we don't so it's largely just a shell of code. */
-
-SELECT
-event_id,  person_id , start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
-
-FROM
-(
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, ROW_NUMBER() OVER (partition by pe.person_id  ORDER BY pe.start_date  ASC ) as ordinal, cast(pe.visit_occurrence_id as bigint) as visit_occurrence_id
-  FROM primary_events pe
-  
-) QE
-
-;
-
-/**The following code is a vestigal part of Atlas-generated code. If we had additional inclusion criteria that further filtered cohort entry, we'd see it here. But we don't so it's largely just a shell of code. **/
-
---- Inclusion Rule Inserts
-
-CREATE TABLE #inclusion_events  (inclusion_rule_id bigint,
-	 person_id bigint,
-	event_id bigint
-)
-DISTKEY(person_id);
-
-CREATE TABLE #included_events
-
-DISTKEY(person_id)
-AS
-WITH
-cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal) 
-AS
-(
-  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, ROW_NUMBER() OVER (partition by person_id  ORDER BY start_date  ASC ) as ordinal
-  from
-  (
-    select Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as bigint), I.inclusion_rule_id), 0)) as inclusion_rule_mask
-    from #qualified_events Q
-    LEFT JOIN #inclusion_events I on I.person_id = Q.person_id and I.event_id = Q.event_id
-    GROUP BY Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date
-  ) MG -- matching groups
-
-)
-
-SELECT
-event_id,  person_id , start_date, end_date, op_start_date, op_end_date
-
-FROM
-cteIncludedEvents Results
-WHERE Results.ordinal = 1
-;
-
-
-/**The following code looks to see how many times people qualify for the cohort because we DO allow people to qualify more than once.**/
--- generate cohort periods into #final_cohort
-CREATE TABLE #cohort_rows
-
-DISTKEY(person_id)
-AS
-WITH
-cohort_ends (event_id, person_id, end_date) 
-AS
-(
-	-- cohort exit dates
-  -- By default, cohort exit at the event's op end date
-select event_id, person_id, op_end_date as end_date from #included_events
-),
-first_ends (person_id, start_date, end_date) as
-(
-	select F.person_id, F.start_date, F.end_date
-	FROM (
-	  select I.event_id, I.person_id, I.start_date, E.end_date, ROW_NUMBER() OVER (partition by I.person_id, I.event_id  ORDER BY E.end_date ) as ordinal 
-	  from #included_events I
-	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
-	) F
-	WHERE F.ordinal = 1
-)
-
-SELECT
- person_id , start_date, end_date
-
-FROM
-first_ends;
-
-/**More Atlas generated code that largely goes unused.**/
 INSERT INTO @resultsDatabaseSchema.n3c_cohort
- WITH cteEndDates (person_id, end_date) AS 
-(	
-	SELECT
-		person_id
-		, DATEADD(day,CAST(-1 * 0 as int),event_date)  as end_date
-	FROM
-	(
-		SELECT
-			person_id
-			, event_date
-			, event_type
-			, MAX(start_ordinal) OVER (PARTITION BY person_id ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal 
-			, ROW_NUMBER() OVER (PARTITION BY person_id  ORDER BY event_date, event_type ) AS overall_ord
-		FROM
-		(
-			SELECT
-				person_id
-				, start_date AS event_date
-				, -1 AS event_type
-				, ROW_NUMBER() OVER (PARTITION BY person_id  ORDER BY start_date ) AS start_ordinal
-			FROM #cohort_rows
-		
-			UNION ALL
-		
-
-			SELECT
-				person_id
-				, DATEADD(day,CAST(0 as int),end_date) as end_date
-				, 1 AS event_type
-				, NULL
-			FROM #cohort_rows
-		) RAWDATA
-	) e
-	WHERE (2 * e.start_ordinal) - e.overall_ord = 0
-),
-cteEnds (person_id, start_date, end_date) AS
+SELECT DISTINCT person_id
+FROM
 (
-	SELECT
-		 c.person_id
-		, c.start_date
-		, MIN(e.end_date) AS end_date
-	FROM #cohort_rows c
-	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
-	GROUP BY c.person_id, c.start_date
-),
-final_cohort (person_id, start_date, end_date) AS
-(
-select person_id, min(start_date) as start_date, end_date
-from cteEnds
-group by person_id, end_date
-)
 
-/**The final collapsing of ALL the logic into the cohort table.**/
---# BEGIN N3C_COHORT table to be retained
+/**
 
---SELECT person_id
- SELECT DISTINCT
-    person_id
-FROM final_cohort;
+INCLUSION:
+
+1) Postive COVID Measurement
+2) Strong positive dx
+3) 2x Weak Dx
+4) COVID Measurement & No occurrences of Z11.59 
+
+
+**/
+
+-- 1) Positive COVID Measurement
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+	AND (
+		value_as_concept_id IN (
+			4126681,
+			45877985,
+			45884084,
+			9191
+			)
+		OR value_source_value IN (
+			'Positive'
+			,'Present'
+			,'Detected'
+			)
+		)
+
+UNION
+
+-- 2) Strong positive 
+-- prior to 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				260125
+				,260139
+				,46271075
+				,4307774
+				,4195694
+				,257011
+				,442555
+				,4059022
+				,4059021
+				,256451
+				,4059003
+				,4168213
+				,434490
+				,439676
+				,254761
+				,4048098
+				,37311061
+				,4100065
+				,320136
+				,4038519
+				,312437
+				,4060052
+				,4263848
+				,37311059
+				,37016200
+				,4011766
+				,437663
+				,4141062
+				,4164645
+				,4047610
+				,4260205
+				,4185711
+				,4289517
+				,4140453
+				,4090569
+				,4109381
+				,4330445
+				,255848
+				,4102774
+				,436235
+				,261326
+				,320651
+				)
+		)
+	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+		AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
+
+UNION
+
+-- after 04-01
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+WHERE condition_concept_id IN (
+		SELECT concept_id
+		FROM @vocabulary_database_schema.CONCEPT
+		WHERE concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @vocabulary_database_schema.CONCEPT c
+		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (
+				756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				,756023
+				,756044
+				,756061
+				,756031
+				,37311061
+				,756081
+				,37310285
+				,756039
+				,37311060
+				)
+			AND c.invalid_reason IS NULL
+		)
+	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+
+UNION
+
+-- 3) 2x Weak diagnosis 
+-- prior to 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					)
+			)
+		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+			AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- after 04-01
+-- same visit 
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,visit_occurrence_id
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+		,condition_start_date
+		,count(*)
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+			WHERE concept_id IN (
+					260125
+					,260139
+					,46271075
+					,4307774
+					,4195694
+					,257011
+					,442555
+					,4059022
+					,4059021
+					,256451
+					,4059003
+					,4168213
+					,434490
+					,439676
+					,254761
+					,4048098
+					,37311061
+					,4100065
+					,320136
+					,4038519
+					,312437
+					,4060052
+					,4263848
+					,37311059
+					,37016200
+					,4011766
+					,437663
+					,4141062
+					,4164645
+					,4047610
+					,4260205
+					,4185711
+					,4289517
+					,4140453
+					,4090569
+					,4109381
+					,4330445
+					,255848
+					,4102774
+					,436235
+					,261326
+					,320651
+					)
+			)
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+	GROUP BY person_id
+		,condition_start_date
+	HAVING count(*) >= 2
+	) dx_same_date
+
+UNION
+
+-- 4) COVID Measurement & No occurrences of Z11.59 
+-- COVID lab test of any result
+SELECT DISTINCT person_id
+FROM @cdmDatabaseSchema.MEASUREMENT
+WHERE measurement_concept_id IN (
+		SELECT concept_id
+		FROM @cdmDatabaseSchema.CONCEPT
+		WHERE concept_id IN (
+				586515
+				,586522
+				,706179
+				,586521
+				,723459
+				,706181
+				,706177
+				,706176
+				,706180
+				,706178
+				,706167
+				,706157
+				,706155
+				,757678
+				,706161
+				,586520
+				,706175
+				,706156
+				,706154
+				,706168
+				,715262
+				,586526
+				,757677
+				,706163
+				,715260
+				,715261
+				,706170
+				,706158
+				,706169
+				,706160
+				,706173
+				,586519
+				,586516
+				,757680
+				,757679
+				,586517
+				,757686
+				,756055
+				)
+		
+		UNION
+		
+		SELECT c.concept_id
+		FROM @cdmDatabaseSchema.CONCEPT c
+		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+			AND ca.ancestor_concept_id IN (756055)
+			AND c.invalid_reason IS NULL
+		)
+	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+	-- existence of Z11.59
+	AND person_id NOT IN (
+		SELECT person_id
+		FROM @cdmDatabaseSchema.OBSERVATION
+		WHERE observation_source_concept_id = 45595484
+			AND observation_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+		)
+		
+		
+) 
+;
+
+
 
 INSERT INTO @resultsDatabaseSchema.phenotype_execution
 SELECT
@@ -940,19 +582,3 @@ SELECT
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
 
-/**Dropping out all the temp tables.**/
-
-TRUNCATE TABLE #cohort_rows;
-DROP TABLE #cohort_rows;
-
-TRUNCATE TABLE #inclusion_events;
-DROP TABLE #inclusion_events;
-
-TRUNCATE TABLE #qualified_events;
-DROP TABLE #qualified_events;
-
-TRUNCATE TABLE #included_events;
-DROP TABLE #included_events;
-
-TRUNCATE TABLE #Codesets;
-DROP TABLE #Codesets;

--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -1,5 +1,5 @@
 /**
-Change log:
+CHANGE LOG:
 V1.1 - initial commit
 V1.2 - updated possible positive cases (typo in name of concept set name) and added additional NIH VSAC codeset_id
 V1.3 - consolidated to single cohort definition and added N3C COHORT table + labeling statements
@@ -11,17 +11,18 @@ changing logic related to inclusion of qualitative test results
 V2.1 - removed HCPCS/CPT4 concept set and PROCEDURE_OCCURRENCE criteria, removed censoring and fixed inclusion entry event instead
 NOTE: LOINC codes from LOINC release V2.68 remain unsupported in the OHDSI vocabulary as of Phenotype V2.1 release. Issue is raised with OHDSI Vocab team and will be updated in concept sets as soon as CONCEPT table includes this and is pushed to community.
 V2.2 - added back OMOP Extension code (765055), removal of generic LOINC codes and recent modification of faulty use of value_as_concept logic
-incremental change on 10-29: simplified script
+Script changes between 10-29 & 11-05: simplified script to human-written SQL (versus ATLAS generated) to enable debugging by individual OMOP sites.
 
-To run, you will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details
+HOW TO RUN:
+You will need to find and replace @cdmDatabaseSchema, @cdmDatabaseSchema with your local OMOP schema details. This is the only modification you should make to this script.
 
-Harmonization note:
-In OHDSI conventions, we do not usually write tables to the main database schema.
-NOTE: OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+USER NOTES: 
+In OHDSI conventions, we do not usually write tables to the main database schema. 
+OHDSI uses @resultsDatabaseSchema as a results schema build cohort tables for specific analysis. 
+We built the N3C_COHORT table in this results schema as we know many OMOP analyst do not have write access to their @cdmDatabaseSchema.
+To follow the logic used in this code, visit: https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/wiki/Latest-Phenotype
 
-
-Begin building cohort following OHDSI standard cohort definition process
-
+SCRIPT RELEASE DATE: 11-05-2020
 
 **/
 
@@ -39,6 +40,7 @@ DISTKEY(person_id);
 DROP TABLE IF EXISTS @resultsDatabaseSchema.phenotype_execution;
 
 -- Create dest table
+-- Here we need to know when you ran the phenotype, what version you're using and what vocabulary version you've built your OMOP concepts on
 CREATE TABLE @resultsDatabaseSchema.phenotype_execution  (run_datetime TIMESTAMP NOT NULL,
 	phenotype_version varchar(50) NOT NULL,
 	vocabulary_version varchar(50) NULL
@@ -51,24 +53,13 @@ SELECT DISTINCT person_id
 FROM
 (
 
-/**
-
-INCLUSION:
-
-1) Postive COVID Measurement
-2) Strong positive dx
-3) 2x Weak Dx
-4) COVID Measurement & No occurrences of Z11.59 
-
-
-**/
-
--- 1) Positive COVID Measurement
+-- Phenotype Entry Criteria: A lab confirmed positive test
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -115,17 +106,26 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
+	-- Here we add a date restriction: after January 1, 2020
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 	AND (
+	-- The value_as_concept field is where we store standardized qualitative results
+	-- The concept ids here represent LOINC or SNOMED codes for standard ways to code a lab that is positive
 		value_as_concept_id IN (
-			4126681,
-			45877985,
-			45884084,
-			9191
+			45878583
+			,37079494
+			,1177295
+			,36307756
+			,36309158
+			,36308436
+			,9189
 			)
+	-- To be exhaustive, we also look for Positive strings in the value_source_value field
 		OR value_source_value IN (
 			'Positive'
 			,'Present'
@@ -135,88 +135,52 @@ WHERE measurement_concept_id IN (
 
 UNION
 
--- 2) Strong positive 
--- prior to 04-01
+-- Phenotype Entry Criteria: ONE or more of the â€œStrong Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables
+-- This section constructs entry logic prior to the CDC guidance issued on April 1, 2020
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				260125
-				,260139
-				,46271075
-				,4307774
-				,4195694
-				,257011
-				,442555
-				,4059022
-				,4059021
-				,256451
-				,4059003
-				,4168213
-				,434490
-				,439676
-				,254761
-				,4048098
-				,37311061
-				,4100065
-				,320136
-				,4038519
-				,312437
-				,4060052
-				,4263848
-				,37311059
-				,37016200
-				,4011766
-				,437663
-				,4141062
-				,4164645
-				,4047610
-				,4260205
-				,4185711
-				,4289517
-				,4140453
-				,4090569
-				,4109381
-				,4330445
-				,255848
-				,4102774
-				,436235
-				,261326
-				,320651
-				)
+			756023,
+			756044,
+			756061,
+			756031,
+			37311061,
+			756081,
+			37310285,
+			756039,
+			320651,
+			37311060
+			)
 		)
+	-- This logic imposes the restriction: these codes were only valid as Strong Positive codes between January 1, 2020 and March 31, 2020
 	AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 		AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
 
 UNION
 
--- after 04-01
+-- The CDC issued guidance on April 1, 2020 that changed COVID coding conventions
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 WHERE condition_concept_id IN (
 		SELECT concept_id
 		FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- This is the list of standard concepts that represent those terms
 		WHERE concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				37311061,
+				37311060,
+				756023,
+				756031,
+				756039,
+				756044,
+				756061,
+				756081,
+				37310285
 				)
 		
 		UNION
@@ -224,90 +188,119 @@ WHERE condition_concept_id IN (
 		SELECT c.concept_id
 		FROM @vocabulary_database_schema.CONCEPT c
 		JOIN @vocabulary_database_schema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Here we pull the descendants (aka terms that are more specific than the concepts selected above)
 			AND ca.ancestor_concept_id IN (
-				756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
-				,756023
-				,756044
-				,756061
-				,756031
-				,37311061
-				,756081
-				,37310285
-				,756039
-				,37311060
+				756044,
+				37310285,
+				37310283,
+				756061,
+				756081,
+				37310287,
+				756023,
+				756031,
+				37310286,
+				37311061,
+				37310284,
+				756039,
+				37311060,
+				37310254
 				)
 			AND c.invalid_reason IS NULL
 		)
+	
 	AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 
 UNION
 
--- 3) 2x Weak diagnosis 
--- prior to 04-01
--- same visit 
+-- 3) TWO or more of the â€œWeak Positiveâ€? diagnosis codes from the ICD-10 or SNOMED tables (below) during the same encounter or on the same date
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same date
+-- BEFORE 04-01-2020 "WEAK POSITIVE" LOGIC:
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
 	GROUP BY person_id
 		,visit_occurrence_id
 	HAVING count(*) >= 2
@@ -315,60 +308,90 @@ FROM (
 
 UNION
 
--- same date
+-- Now we apply logic to look for same visit AND same date
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,condition_start_date
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
 			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971
 					)
 			)
+		-- This code list is only valid for CDC guidance before 04-01-2020
 		AND condition_start_date BETWEEN TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 			AND TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(03,'00FM')||'-'||TO_CHAR(31,'00FM'), 'YYYY-MM-DD')
 	GROUP BY person_id
@@ -378,17 +401,113 @@ FROM (
 
 UNION
 
--- after 04-01
--- same visit 
+-- AFTER 04-01-2020 "WEAK POSITIVE" LOGIC:
+-- Here we start looking in the CONDITION_OCCCURRENCE table for visits on the same visit
+
 SELECT DISTINCT person_id
 FROM (
 	SELECT person_id
-		,visit_occurrence_id
-		,count(*)
 	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
 	WHERE condition_concept_id IN (
 			SELECT concept_id
 			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those terms	
+			WHERE concept_id IN (
+					260125,
+					260139,
+					46271075,
+					4307774,
+					4195694,
+					257011,
+					442555,
+					4059022,
+					4059021,
+					256451,
+					4059003,
+					4168213,
+					434490,
+					439676,
+					254761,
+					4048098,
+					37311061,
+					4100065,
+					320136,
+					4038519,
+					312437,
+					4060052,
+					4263848,
+					37311059,
+					37016200,
+					4011766,
+					437663,
+					4141062,
+					4164645,
+					4047610,
+					4260205,
+					4185711,
+					4289517,
+					4140453,
+					4090569,
+					4109381,
+					4330445,
+					255848,
+					4102774,
+					436235,
+					261326,
+					436145,
+					40482061,
+					439857,
+					254677,
+					40479642,
+					256722,
+					4133224,
+					4310964,
+					4051332,
+					4112521,
+					4110484,
+					4112015,
+					4110023,
+					4112359,
+					4110483,
+					4110485,
+					254058,
+					40482069,
+					4256228,
+					37016114,
+					46273719,
+					312940,
+					36716978,
+					37395564,
+					4140438,
+					46271074,
+					319049,
+					314971,
+					320651
+					)
+			)
+	-- This code list is only valid for CDC guidance before 04-01-2020
+		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
+	-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
+		,visit_occurrence_id
+	HAVING count(*) >= 2
+	) dx_same_encounter
+
+UNION
+
+-- Now we apply logic to look for same visit AND same date
+SELECT DISTINCT person_id
+FROM (
+	SELECT person_id
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
+	WHERE condition_concept_id IN (
+			SELECT concept_id
+			FROM @vocabulary_database_schema.CONCEPT
+		-- The list of ICD-10 codes in the Phenotype Wiki were translated into OMOP standard concepts
+		-- It also includes the OMOP only codes that are on the Phenotype Wiki
+		-- This is the list of standard concepts that represent those term
 			WHERE concept_id IN (
 					260125
 					,260139
@@ -434,84 +553,27 @@ FROM (
 					,320651
 					)
 			)
+		-- This code list is based on CDC Guidance for code use AFTER 04-01-2020
 		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
-	GROUP BY person_id
-		,visit_occurrence_id
-	HAVING count(*) >= 2
-	) dx_same_encounter
-
-UNION
-
--- same date
-SELECT DISTINCT person_id
-FROM (
-	SELECT person_id
-		,condition_start_date
-		,count(*)
-	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE
-	WHERE condition_concept_id IN (
-			SELECT concept_id
-			FROM @vocabulary_database_schema.CONCEPT
-			WHERE concept_id IN (
-					260125
-					,260139
-					,46271075
-					,4307774
-					,4195694
-					,257011
-					,442555
-					,4059022
-					,4059021
-					,256451
-					,4059003
-					,4168213
-					,434490
-					,439676
-					,254761
-					,4048098
-					,37311061
-					,4100065
-					,320136
-					,4038519
-					,312437
-					,4060052
-					,4263848
-					,37311059
-					,37016200
-					,4011766
-					,437663
-					,4141062
-					,4164645
-					,4047610
-					,4260205
-					,4185711
-					,4289517
-					,4140453
-					,4090569
-					,4109381
-					,4330445
-					,255848
-					,4102774
-					,436235
-					,261326
-					,320651
-					)
-			)
-		AND condition_start_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(04,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
-	GROUP BY person_id
+-- Now we group by person_id and visit_occurrence_id to find people who have 2 or more
+		GROUP BY person_id
 		,condition_start_date
 	HAVING count(*) >= 2
 	) dx_same_date
 
 UNION
 
--- 4) COVID Measurement & No occurrences of Z11.59 
--- COVID lab test of any result
+-- 4) ONE or more of the lab tests in the Labs table, regardless of result (unless negative and accompanied by a Z11.59)
+-- Patient was assigned code Z11.59 (viral screening code; used per CDC guidance to indicate asymptomatic covid screening) on or after 4/1/2020, 
+-- and does NOT also have a record of a positive covid test or a â€œstrong positiveâ€? diagnosis code.
+
+-- We begin by looking for ANY COVID measurement
 SELECT DISTINCT person_id
 FROM @cdmDatabaseSchema.MEASUREMENT
 WHERE measurement_concept_id IN (
 		SELECT concept_id
 		FROM @cdmDatabaseSchema.CONCEPT
+		-- here we look for the concepts that are the LOINC codes we're looking for in the phenotype
 		WHERE concept_id IN (
 				586515
 				,586522
@@ -558,11 +620,15 @@ WHERE measurement_concept_id IN (
 		SELECT c.concept_id
 		FROM @cdmDatabaseSchema.CONCEPT c
 		JOIN @cdmDatabaseSchema.CONCEPT_ANCESTOR ca ON c.concept_id = ca.descendant_concept_id
+		-- Most of the LOINC codes do not have descendants but there is one OMOP Extension code (765055) in use that has descendants which we want to pull
+		-- This statement pulls the descendants of that specific code
 			AND ca.ancestor_concept_id IN (756055)
 			AND c.invalid_reason IS NULL
 		)
 	AND measurement_date >= TO_DATE(TO_CHAR(2020,'0000FM')||'-'||TO_CHAR(01,'00FM')||'-'||TO_CHAR(01,'00FM'), 'YYYY-MM-DD')
 	-- existence of Z11.59
+	-- Z11.59 here is being pulled from the source_concept_id
+	-- we want to make extra sure that we're ONLY looking at Z11.59 not the more general SNOMED code that would be in the standard concept id column for this
 	AND person_id NOT IN (
 		SELECT person_id
 		FROM @cdmDatabaseSchema.OBSERVATION
@@ -581,4 +647,3 @@ SELECT
     CURRENT_DATE as run_datetime
     ,'2.2' as phenotype_version
     , (SELECT TOP 1 vocabulary_version FROM @cdmDatabaseSchema.vocabulary WHERE vocabulary_id='None') AS VOCABULARY_VERSION;
-


### PR DESCRIPTION
Based on site feedback and numerous issues with troubleshooting ATLAS-generated SQL, we've done the following:
- Simplified the OMOP Phenotype script to be human-generated SQL with comments to explain how the code functions
- Removed dependency on OBSERVATION table to look for Z11.59. The prior code looked for a record in the OBSERVATION table first and then applied logic to look for allowable lab-confirmed negatives. This may have caused attrition in sites where persons captured in the MEASUREMENT table > persons captured in the OBSERVATION table.
- Tested the logic on 2 sites to ensure this works for multiple submitters.

**Note:** we anticipate sites will have an uptick in counts of lab-confirmed negatives because of the overly restrictive prior logic in 2.1 / 2.2. Not a DQ issue was actually a coding issue.