### PR TITLE
Python bigquery changes

### DIFF
--- a/Exporters/PythonExporter/README.MD
+++ b/Exporters/PythonExporter/README.MD
@@ -30,14 +30,14 @@ You can (optionally) use our Python Data Exporter to run the N3C data extract sc
 
 
 *   Python 3.x
-*   Oracle or MS SqlServer
-*   If you are using MS SqlServer, you will need to have package pyodbc installed (pip install pyodbc)
+*   Oracle, MS SqlServer, or Google BigQuery
+*   If you are using MS SqlServer or Google BigQuery, you will need to have package pyodbc installed (pip install pyodbc)
 *   If you are using Oracle, you will need to have package cx_Oracle installed (pip install cx_Oracle) as well as the Oracle client libraries.  [More information about cx_Oracle installation](https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html)
 *   To use the sftp feature, you may need to install paramiko:  python -m pip install paramiko
 *   You should have already copied one of the [extract SQL files](https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/tree/master/ExtractScripts) and [phenotype SQL file](https://github.com/National-COVID-Cohort-Collaborative/Phenotype_Data_Acquisition/tree/master/PhenotypeScripts) to a local directory.
+*	Google BigQuery requires installation of Simba ODBC drivers (https://cloud.google.com/bigquery/providers/simba-drivers)
 
 **Running the Exporter**
-
 
 
 1. Copy or download the contents of this folder to your local system. To make it easy, use the same directory where your extract SQL and phenotype SQL files are located.
@@ -57,8 +57,11 @@ python db_exp.py --config config.ini --database oracle --phenotype N3C_phenotype
 *   --config (config file name)  See file "config_example.ini"
 *   --phenotype (phenotype SQL file name)
 *   --extract (extract SQL file name)
-*   --database (oracle or mssql)
+*   --database (oracle, mssql, or bigquery)
 *   --output_dir (output directory for export)   Output directory must have a sub-directory "datafiles".
+*   --storedata Stores all data files in local DBMS
+*   --storevocab Stores current vocabulary files in local DBMS
+*   --nocsv Runs extract script but does not write CSV. If --storedata, data stored only in local DBMS.
 *   --zip
 *   --sftp
 *   --debug
@@ -81,3 +84,4 @@ Once you run the exporter, your files will be output in the following directory 
 **Bug Reports/Enhancement Requests/Contributions**
 
 We would love to hear from you about this script, as we hope to continue to improve and enhance it. We also welcome contributions, if there’s a cool feature you’ve added locally. Please feel free to open an issue or create a pull request as needed!
+

--- a/Exporters/PythonExporter/config_ini_example.txt
+++ b/Exporters/PythonExporter/config_ini_example.txt
@@ -20,6 +20,14 @@ service_name =
 user = xxxxx
 pwd = xxxxx
 
+[bigquery]
+; assumes OAuthMechanism = 0 (Service Account IAM)
+; config parms from Simba documentation
+oauthserviceacctemail = Service account email
+oauthpvtkeypath = Path to Service account json key file
+projectid = GBQ project for storing all data sets/schemas
+driver = Logical name of Simbal ODBC drivers odbc.ini(Mac/Linxu); ODBC Database Admininstrator(windows) eg: Simba ODBC Driver for Google BigQuery
+
 ; for zip file creation
 ; and for sql parameters
 [site]

--- a/ExtractScripts/N3C_extract_omop_bigquery.sql
+++ b/ExtractScripts/N3C_extract_omop_bigquery.sql
@@ -218,12 +218,12 @@ select
    cast(condition_end_datetime as datetime) as condition_end_datetime,
    condition_type_concept_id,
    condition_status_concept_id,
-   null as stop_reason,
+   cast(null as string) as stop_reason,
    visit_occurrence_id,
-   null as visit_detail_id,
+   cast(null as int64) as visit_detail_id,
    condition_source_value,
    condition_source_concept_id,
-   null as condition_status_source_value
+   cast(null as string) as condition_status_source_value
 from @cdmDatabaseSchema.condition_occurrence co
 join @resultsDatabaseSchema.n3c_cohort n
   on co.person_id = n.person_id
@@ -240,16 +240,16 @@ select
    cast(drug_exposure_end_date as datetime) as drug_exposure_end_date,
    cast(drug_exposure_end_datetime as datetime) as drug_exposure_end_datetime,
    drug_type_concept_id,
-   null as stop_reason,
+   cast(null as string) as stop_reason,
    refills,
    quantity,
    days_supply,
-   null as sig,
+   cast(null as string) as sig,
    route_concept_id,
    lot_number,
    provider_id,
    visit_occurrence_id,
-   null as visit_detail_id,
+   cast(null as int64) as visit_detail_id,
    drug_source_value,
    drug_source_concept_id,
    route_source_value,
@@ -272,10 +272,10 @@ select
    quantity,
    provider_id,
    visit_occurrence_id,
-   null as visit_detail_id,
+   cast(null as int64) as visit_detail_id,
    procedure_source_value,
    procedure_source_concept_id,
-   null as modifier_source_value
+   cast(null as string) as modifier_source_value
 from @cdmDatabaseSchema.procedure_occurrence po
 join @resultsDatabaseSchema.n3c_cohort n
   on po.person_id = n.person_id
@@ -289,7 +289,7 @@ select
    measurement_concept_id,
    cast(measurement_date as datetime) as measurement_date,
    cast(measurement_datetime as datetime) as measurement_datetime,
-   null as measurement_time,
+   cast(null as string) as measurement_time,
    measurement_type_concept_id,
    operator_concept_id,
    value_as_number,
@@ -299,11 +299,11 @@ select
    range_high,
    provider_id,
    visit_occurrence_id,
-   null as visit_detail_id,
+   cast(null as int64) as visit_detail_id,
    measurement_source_value,
    measurement_source_concept_id,
-   null as unit_source_value,
-   null as value_source_value
+   cast(null as string) as unit_source_value,
+   cast(null as string) as value_source_value
 from @cdmDatabaseSchema.measurement m
 join @resultsDatabaseSchema.n3c_cohort n
   on m.person_id = n.person_id
@@ -325,11 +325,11 @@ select
    unit_concept_id,
    provider_id,
    visit_occurrence_id,
-   null as visit_detail_id,
+   cast(null as int64) as visit_detail_id,
    observation_source_value,
    observation_source_concept_id,
-   null as unit_source_value,
-   null as qualifier_source_value
+   cast(null as string) as unit_source_value,
+   cast(null as string) as qualifier_source_value
 from @cdmDatabaseSchema.observation o
 join @resultsDatabaseSchema.n3c_cohort n
   on o.person_id = n.person_id
@@ -343,7 +343,7 @@ select
 	cast(death_datetime as datetime) as death_datetime,
 	death_type_concept_id,
 	cause_concept_id,
-	null as cause_source_value,
+	cast(null as string) as cause_source_value,
 	cause_source_concept_id
 from @cdmDatabaseSchema.death d
 join @resultsDatabaseSchema.n3c_cohort n
@@ -354,13 +354,13 @@ where d.death_date >= DATE(2020, 01, 01);
 --OUTPUT_FILE: LOCATION.csv
 select
    l.location_id,
-   null as address_1, -- to avoid identifying information
-   null as address_2, -- to avoid identifying information
+   cast(null as string) as address_1, -- to avoid identifying information
+   cast(null as string) as address_2, -- to avoid identifying information
    city,
    state,
    zip,
    county,
-   null as location_source_value
+   cast(null as string) as location_source_value
 from @cdmDatabaseSchema.location l
 join (
         select distinct p.location_id
@@ -377,9 +377,9 @@ select
    cs.care_site_id,
    care_site_name,
    place_of_service_concept_id,
-   null as location_id,
-   null as care_site_source_value,
-   null as place_of_service_source_value
+   cast(null as int64) as location_id,
+   cast(null as string) as care_site_source_value,
+   cast(null as string) as place_of_service_source_value
 from @cdmDatabaseSchema.care_site cs
 join (
         select distinct care_site_id
@@ -394,14 +394,14 @@ join (
 --OUTPUT_FILE: PROVIDER.csv
 select
    pr.provider_id,
-   null as provider_name, -- to avoid accidentally identifying sites
-   null as npi, -- to avoid accidentally identifying sites
-   null as dea, -- to avoid accidentally identifying sites
+   cast(null as string) as provider_name, -- to avoid accidentally identifying sites
+   cast(null as string) as npi, -- to avoid accidentally identifying sites
+   cast(null as string) as dea, -- to avoid accidentally identifying sites
    specialty_concept_id,
    care_site_id,
-   null as year_of_birth,
+   cast(null as int64) as year_of_birth,
    gender_concept_id,
-   null as provider_source_value, -- to avoid accidentally identifying sites
+   cast(null as string) as provider_source_value, -- to avoid accidentally identifying sites
    specialty_source_value,
    specialty_source_concept_id,
    gender_source_value,


### PR DESCRIPTION
A number of change to python script and associated files:

- Add bigquery_connect() for accessing Google BigQuery backend
- Include BigQuery configuration params in example config.ini
- Three new options to python script command line
(a) --storedata: uses export script file to store data in local DBMS
(b) --storevocab: stores current vocabs in local DBMS
(c) --nocsv: suppresses CSV file export: Used with --storedata if you only want to store data in DBMS w/o writing CSVs
- Add explicit case for NULL AS fields for target data type. In GBQ, "NULL AS" converts field to INT64 irrespective of original data type, breaking data model when NULL field should be STRING/CHAR. Not an issue with CSV but an issue with --storedata into DBMS
- Updated README.MD to reflect above changes.