### PR TITLE
BigQuery: Replace TO_DATE() with DATE()

### DIFF
--- a/ExtractScripts/N3C_extract_omop_bigquery.sql
+++ b/ExtractScripts/N3C_extract_omop_bigquery.sql
@@ -189,7 +189,7 @@ select
  from @cdmDatabaseSchema.observation_period p
  join @resultsDatabaseSchema.n3c_cohort n
    on p.person_id = n.person_id
-   and (p.observation_period_start_date >= TO_DATE(TO_CHAR(2018,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD') OR p.observation_period_end_date >= TO_DATE(TO_CHAR(2018,'0000')||'-'||TO_CHAR(01,'00')||'-'||TO_CHAR(01,'00'), 'YYYY-MM-DD'));
+   and (p.observation_period_start_date >= DATE(2018,01,01) OR p.observation_period_end_date >= DATE(2018,01,01));
 
 --VISIT_OCCURRENCE
 --OUTPUT_FILE: VISIT_OCCURRENCE.csv


### PR DESCRIPTION
TO_DATE() is not a valid BigQuery function. Replaced with DATE() function. Code executes on BigQuery instance w/o error.