### PR TITLE
fix for issue #232

### DIFF
--- a/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
+++ b/PhenotypeScripts/N3C_phenotype_omop_redshift.sql
@@ -969,7 +969,7 @@ WHERE CASE_person_id NOT IN (
 
 INSERT INTO @resultsDatabaseSchema.N3C_CONTROL_MAP
 SELECT
-		person_id, 1 as buddy_num, NULL
+		person_id, 1 as buddy_num, CAST(NULL as INTEGER)
 		FROM @resultsDatabaseSchema.n3c_case_cohort
 		WHERE person_id NOT IN (
 			SELECT case_person_id
@@ -979,7 +979,7 @@ SELECT
 
 		UNION
 
-		SELECT person_id, 2 as buddy_num, NULL
+		SELECT person_id, 2 as buddy_num, CAST(NULL as INTEGER)
 		FROM @resultsDatabaseSchema.n3c_case_cohort
 		WHERE person_id NOT IN (
 			SELECT case_person_id


### PR DESCRIPTION
Corrects 

Error executing SQL:
com.amazon.redshift.util.RedshiftException: ERROR: column "control_person_id" is of type integer but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.

for redshift in query
```
     INSERT INTO n3c_ncats.N3C_CONTROL_MAP
     SELECT
 		person_id, 1 as buddy_num, NULL
 		FROM n3c_ncats.n3c_case_cohort
 		WHERE person_id NOT IN (
 			SELECT case_person_id
 			FROM n3c_ncats.N3C_CONTROL_MAP
 			WHERE buddy_num = 1
 			)
 
 		UNION
 
 		SELECT person_id, 2 as buddy_num, NULL
 		FROM n3c_ncats.n3c_case_cohort
 		WHERE person_id NOT IN (
 			SELECT case_person_id
 			FROM n3c_ncats.N3C_CONTROL_MAP
 			WHERE buddy_num = 2
 			)
```