### PR TITLE
grab csv files in DATAFILES subdir and its parent, but do not recurse…

### DIFF
--- a/Exporters/RExporter/example_execution.R
+++ b/Exporters/RExporter/example_execution.R
@@ -118,4 +118,4 @@ N3cOhdsi::runExtraction(connectionDetails = connectionDetails,
 
 # Compress output
 zip::zipr(zipfile = paste0(siteAbbrev, "_", cdmName, "_", format(Sys.Date(),"%Y%m%d"),".zip"),
-          files = list.files(outputFolder, full.names = TRUE))
+          files = list.files(path=c(outputFolder,paste0(outputFolder,"DATAFILES/")), pattern="csv$", full.names=TRUE))


### PR DESCRIPTION
… other subdirectories*

Note: this "flattens" the directory structure.  It also presently will still write to the current working directory in R (not necessarily outputFolder).

*assuming such directories don't themselves end with csv

ToDos: 
1. make "csv" case insensitive.
2. consider retaining folder structure.
3. specifically exclude subdirectories, even if named (or ending in) csv 
4. output zip file to outputFolder
5. consider renaming csv files to psv (upstream)